### PR TITLE
Unit tests added

### DIFF
--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "dnspython==2.6.1",
     "pydantic==2.8.2",
     "fastapi[standard]>=0.113.0,<0.114.0",
-    "open-mpic-core==3.0.2",
+    "open-mpic-core==3.0.7",
     "uvicorn>=0.22.0,<0.23.0",
 ]
 

--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "dnspython==2.6.1",
     "pydantic==2.8.2",
     "fastapi[standard]>=0.113.0,<0.114.0",
-    "open-mpic-core==3.0.7",
+    "open-mpic-core==3.1.0",
     "uvicorn>=0.22.0,<0.23.0",
 ]
 
@@ -85,7 +85,7 @@ randomize = true
 
 [tool.pytest.ini_options]
 pythonpath = [
-    "src", "tests", "." # need root directory because it has some python utility files we are importing for integration tests
+    "src", "tests"
 ]
 testpaths = [
     "tests/unit"
@@ -100,8 +100,6 @@ markers = [
 addopts = [
     "--import-mode=prepend",  # explicit default, as the tests rely on it for proper import resolution
 ]
-spec_header_format = "Spec for {test_case} ({path}):"
-spec_test_format = "{result} {docstring_summary}"  # defaults to {name} if docstring is not present in test
 
 [tool.coverage.run]
 source = [

--- a/api-implementation/src/mpic_caa_checker_service/main.py
+++ b/api-implementation/src/mpic_caa_checker_service/main.py
@@ -21,12 +21,6 @@ class MpicCaaCheckerService:
 
     def check_caa(self, caa_request: CaaCheckRequest):
         return self.caa_checker.check_caa(caa_request)
-        # result = {
-        #     'statusCode': 200,  # note: must be snakeCase
-        #     'headers': {'Content-Type': 'application/json'},
-        #     'body': caa_response.model_dump_json()
-        # }
-        # return result
 
 
 # Global instance for Lambda runtime
@@ -47,5 +41,5 @@ app = FastAPI()
 
 
 @app.post("/caa")
-def perform_mpic(request: CaaCheckRequest):
+def handle_caa_check(request: CaaCheckRequest):
     return get_service().check_caa(request)

--- a/api-implementation/src/mpic_coordinator_service/main.py
+++ b/api-implementation/src/mpic_coordinator_service/main.py
@@ -1,14 +1,13 @@
 import json
 from pathlib import Path
-from typing import Union
 
-from fastapi import FastAPI, Request, status, HTTPException
+from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from open_mpic_core.mpic_coordinator.domain.mpic_request_validation_error import MpicRequestValidationError
 from open_mpic_core.mpic_coordinator.messages.mpic_request_validation_messages import MpicRequestValidationMessages
 
-from pydantic import TypeAdapter, ValidationError, BaseModel, Field
+from pydantic import TypeAdapter, BaseModel, Field
 from open_mpic_core.common_domain.check_request import BaseCheckRequest
 from open_mpic_core.common_domain.check_response import CheckResponse
 from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicRequest
@@ -20,7 +19,6 @@ from open_mpic_core.mpic_coordinator.domain.mpic_response import MpicResponse
 import yaml
 import requests
 import os
-import traceback
 from dotenv import load_dotenv
 
 # 'config' directory should be a sibling of the directory containing this file
@@ -132,6 +130,7 @@ def get_service() -> MpicCoordinatorService:
 app = FastAPI()
 
 
+# noinspection PyUnusedLocal
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, e: RequestValidationError):
     return JSONResponse(
@@ -143,6 +142,7 @@ async def validation_exception_handler(request: Request, e: RequestValidationErr
     )
 
 
+# noinspection PyUnusedLocal
 @app.exception_handler(MpicRequestValidationError)
 async def mpic_validation_exception_handler(request: Request, e: MpicRequestValidationError):
     return JSONResponse(

--- a/api-implementation/src/mpic_coordinator_service/resources/available_perspectives.yaml
+++ b/api-implementation/src/mpic_coordinator_service/resources/available_perspectives.yaml
@@ -1,11 +1,11 @@
 available_regions:
   -
     code: "test-1"
-    name: "Test Region 1"
+    name: "Replace file contents with a proper configuration 1"
     rir: "rir1"
     too_close_codes: []
   -
     code: "test-2"
-    name: "Test Region 2"
+    name: "Replace file contents with a proper configuration 2"
     rir: "rir2"
     too_close_codes: []

--- a/api-implementation/tests/resources/available_test_perspectives.yaml
+++ b/api-implementation/tests/resources/available_test_perspectives.yaml
@@ -1,0 +1,42 @@
+# this file is used for unit testing; do not edit it or move it without updating and running the tests
+available_regions:
+  -
+    code: "test-1"
+    name: "Test Region 1"
+    rir: "rir1"
+    too_close_codes: []
+  -
+    code: "test-2"
+    name: "Test Region 2"
+    rir: "rir1"
+    too_close_codes: []
+  -
+    code: "test-3"
+    name: "Test Region 3"
+    rir: "rir1"
+    too_close_codes: []
+  -
+    code: "test-4"
+    name: "Test Region 4"
+    rir: "rir2"
+    too_close_codes: []
+  -
+    code: "test-5"
+    name: "Test Region 5"
+    rir: "rir2"
+    too_close_codes: []
+  -
+    code: "test-6"
+    name: "Test Region 6"
+    rir: "rir3"
+    too_close_codes: []
+  -
+    code: "test-7"
+    name: "Test Region 7"
+    rir: "rir1"
+    too_close_codes: ['test-8']
+  -
+    code: "test-8"
+    name: "Test Region 8"
+    rir: "rir1"
+    too_close_codes: ['test-7']

--- a/api-implementation/tests/unit/test_mpic_caa_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_caa_checker_service.py
@@ -1,11 +1,13 @@
 import time
-
 import pytest
+
 from fastapi import status
+from fastapi.testclient import TestClient
+
 from open_mpic_core.common_domain.check_response import CaaCheckResponse
 from open_mpic_core.common_domain.check_response_details import CaaCheckResponseDetails
 from open_mpic_core_test.test_util.valid_check_creator import ValidCheckCreator
-from fastapi.testclient import TestClient
+
 from mpic_caa_checker_service.main import MpicCaaCheckerService, app
 
 

--- a/api-implementation/tests/unit/test_mpic_caa_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_caa_checker_service.py
@@ -1,13 +1,52 @@
-import os
+import time
 
 import pytest
+from fastapi import status
+from open_mpic_core.common_domain.check_response import CaaCheckResponse
+from open_mpic_core.common_domain.check_response_details import CaaCheckResponseDetails
+from open_mpic_core_test.test_util.valid_check_creator import ValidCheckCreator
+from fastapi.testclient import TestClient
+from mpic_caa_checker_service.main import MpicCaaCheckerService, app
 
-from mpic_caa_checker_service.main import MpicCaaCheckerService
+
+client = TestClient(app)
 
 
 # noinspection PyMethodMayBeStatic
-class TestMpicCaaCheckerServiceLambda:
+class TestMpicCaaCheckerService:
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def set_env_variables():
+        envvars = {
+            'AWS_REGION': 'us-east-1',
+            'default_caa_domains': 'ca1.com|ca2.org|ca3.net'
+        }
+        with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
+            for k, v in envvars.items():
+                class_scoped_monkeypatch.setenv(k, v)
+            yield class_scoped_monkeypatch  # restore the environment afterward
+
+    # noinspection PyMethodMayBeStatic
+    def service__should_do_caa_check_using_configured_caa_checker(self, set_env_variables, mocker):
+        mock_caa_result = TestMpicCaaCheckerService.create_caa_check_response()
+        mocker.patch('open_mpic_core.mpic_caa_checker.mpic_caa_checker.MpicCaaChecker.check_caa', return_value=mock_caa_result)
+        caa_check_request = ValidCheckCreator.create_valid_caa_check_request()
+        response = client.post('/caa', json=caa_check_request.model_dump())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == mock_caa_result.model_dump()
+
     def service__should_read_in_environment_configuration_through_config_file(self):
         service = MpicCaaCheckerService()
         # it'll read in the placeholder values in the config files -- that's acceptable for this particular test
         assert service.perspective_code == 'PERSPECTIVE_NAME_CODE_STRING'
+
+    @staticmethod
+    def create_caa_check_response():
+        return CaaCheckResponse(perspective_code='us-east-1', check_passed=True,
+                                details=CaaCheckResponseDetails(caa_record_present=True,
+                                                                found_at='example.com'),
+                                timestamp_ns=time.time_ns())
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/api-implementation/tests/unit/test_mpic_coordinator_service.py
+++ b/api-implementation/tests/unit/test_mpic_coordinator_service.py
@@ -1,12 +1,15 @@
 import json
+import yaml
+import pytest
+
 from importlib import resources
 from io import BytesIO
 from unittest.mock import patch
-
-import pytest
-import yaml
 from fastapi import status
 from fastapi.testclient import TestClient
+from pydantic import TypeAdapter
+from requests import Response
+
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.check_response import DcvCheckResponse
 from open_mpic_core.common_domain.check_response_details import DcvDnsCheckResponseDetails
@@ -15,8 +18,6 @@ from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidatio
 from open_mpic_core.mpic_coordinator.domain.mpic_orchestration_parameters import MpicEffectiveOrchestrationParameters
 from open_mpic_core.mpic_coordinator.domain.mpic_response import MpicCaaResponse
 from open_mpic_core.mpic_coordinator.domain.remote_perspective import RemotePerspective
-from pydantic import TypeAdapter
-from requests import Response
 
 from mpic_coordinator_service.main import MpicCoordinatorService, PerspectiveEndpoints, PerspectiveEndpointInfo, app
 from open_mpic_core_test.test_util.valid_mpic_request_creator import ValidMpicRequestCreator

--- a/api-implementation/tests/unit/test_mpic_coordinator_service.py
+++ b/api-implementation/tests/unit/test_mpic_coordinator_service.py
@@ -1,16 +1,42 @@
 import json
 from importlib import resources
+from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 import yaml
+from fastapi import status
+from fastapi.testclient import TestClient
+from open_mpic_core.common_domain.check_request import DcvCheckRequest
+from open_mpic_core.common_domain.check_response import DcvCheckResponse
+from open_mpic_core.common_domain.check_response_details import DcvDnsCheckResponseDetails
+from open_mpic_core.common_domain.enum.check_type import CheckType
+from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
+from open_mpic_core.mpic_coordinator.domain.mpic_orchestration_parameters import MpicEffectiveOrchestrationParameters
+from open_mpic_core.mpic_coordinator.domain.mpic_response import MpicCaaResponse
 from open_mpic_core.mpic_coordinator.domain.remote_perspective import RemotePerspective
 from pydantic import TypeAdapter
+from requests import Response
 
-from mpic_coordinator_service.main import MpicCoordinatorService, PerspectiveEndpoints, PerspectiveEndpointInfo
+from mpic_coordinator_service.main import MpicCoordinatorService, PerspectiveEndpoints, PerspectiveEndpointInfo, app
+from open_mpic_core_test.test_util.valid_mpic_request_creator import ValidMpicRequestCreator
+from open_mpic_core_test.test_util.valid_check_creator import ValidCheckCreator
+
+
+client = TestClient(app)
 
 
 # noinspection PyMethodMayBeStatic
 class TestMpicCoordinatorService:
+    @pytest.fixture(autouse=True)
+    def mock_yaml_load(self):
+        with resources.files('resources').joinpath('available_test_perspectives.yaml').open('r') as file:
+            perspectives_yaml = yaml.safe_load(file)
+
+        with patch('mpic_coordinator_service.main.yaml.safe_load') as mock:
+            mock.return_value = perspectives_yaml
+            yield mock
+
     @staticmethod
     @pytest.fixture(scope='function')
     def set_env_variables():
@@ -48,19 +74,79 @@ class TestMpicCoordinatorService:
         for target_perspective in mpic_coordinator_service.target_perspectives:
             assert target_perspective in all_possible_perspectives.values()
         mpic_coordinator = mpic_coordinator_service.mpic_coordinator
-        assert len(mpic_coordinator.target_perspectives) == 2
+        assert len(mpic_coordinator.target_perspectives) == 6
         assert mpic_coordinator_service.hash_secret == 'test_secret'
         assert mpic_coordinator_service.default_perspective_count == 2
         assert mpic_coordinator_service.global_max_attempts == 2
+
+    def load_available_perspectives_config__should_return_dict_of_perspectives_with_proximity_info_by_region_code(self):
+        perspectives = MpicCoordinatorService.load_available_perspectives_config()
+        expected_perspectives = TestMpicCoordinatorService.get_perspectives_by_code_dict_from_file()
+        assert len(perspectives) == len(expected_perspectives)
+        assert 'test-1' in perspectives
+        assert 'test-7' in perspectives['test-8'].too_close_codes
+
+    def call_remote_perspective__should_call_remote_perspective_with_provided_arguments_and_return_check_response(self, set_env_variables, mocker):
+        mocker.patch('requests.post', side_effect=self.create_successful_api_call_response_for_dcv_check)
+        dcv_check_request = ValidCheckCreator.create_valid_dns_check_request()
+        service = MpicCoordinatorService()
+        check_response = service.call_remote_perspective(
+            RemotePerspective(code='test-1', rir='rir1'), CheckType.DCV, dcv_check_request
+        )
+        assert check_response.check_passed is True
+        # hijacking the value of 'perspective_code' to verify that the right arguments got passed to the call
+        assert check_response.perspective_code == dcv_check_request.domain_or_ip_target
 
     def service__should_read_in_environment_configuration_through_config_file(self, set_some_env_variables):
         mpic_coordinator_service = MpicCoordinatorService()
         # it'll read in the placeholder values in the config files -- that's acceptable for this particular test
         assert mpic_coordinator_service.hash_secret == 'HASH_SECRET_STRING'
 
+    def service__should_return_400_error_and_details_given_invalid_request_body(self, set_env_variables):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        # noinspection PyTypeChecker
+        request.domain_or_ip_target = None
+        response = client.post('/mpic', json=request.model_dump())
+        assert response.status_code == 400
+        result_body = json.loads(response.text)
+        assert result_body['validation_issues'][0]['type'] == 'string_type'
+
+    def service__should_return_400_error_and_details_given_invalid_check_type(self, set_env_variables):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        request.check_type = 'invalid_check_type'
+        response = client.post('/mpic', json=request.model_dump())
+        assert response.status_code == 400
+        result_body = json.loads(response.text)
+        assert result_body['validation_issues'][0]['type'] == 'literal_error'
+
+    def service__should_return_400_error_given_logically_invalid_request(self, set_env_variables):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        request.orchestration_parameters.perspective_count = 1
+        response = client.post('/mpic', json=request.model_dump())
+        assert response.status_code == 400
+        result_body = json.loads(response.text)
+        assert result_body['validation_issues'][0]['issue_type'] == 'invalid-perspective-count'
+
+    def service__should_return_500_error_given_other_unexpected_errors(self, set_env_variables, mocker):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        mocker.patch('open_mpic_core.mpic_coordinator.mpic_coordinator.MpicCoordinator.coordinate_mpic',
+                     side_effect=Exception('Something went wrong'))
+        response = client.post('/mpic', json=request.model_dump())
+        assert response.status_code == 500
+
+    def service__should_coordinate_mpic_using_configured_mpic_coordinator(self, set_env_variables, mocker):
+        mpic_request = ValidMpicRequestCreator.create_valid_mpic_request(CheckType.CAA)
+        mock_return_value = TestMpicCoordinatorService.create_caa_mpic_response()
+        mocker.patch('open_mpic_core.mpic_coordinator.mpic_coordinator.MpicCoordinator.coordinate_mpic',
+                     return_value=mock_return_value)
+        response = client.post('/mpic', json=mpic_request.model_dump())
+        assert response.status_code == status.HTTP_200_OK
+        result_body = json.loads(response.text)
+        assert result_body['is_valid'] is True
+
     @staticmethod
     def get_perspectives_by_code_dict_from_file() -> dict[str, RemotePerspective]:
-        with resources.files('mpic_coordinator_service.resources').joinpath('available_perspectives.yaml').open('r') as file:
+        with resources.files('resources').joinpath('available_test_perspectives.yaml').open('r') as file:
             perspectives_yaml = yaml.safe_load(file)
             perspective_type_adapter = TypeAdapter(list[RemotePerspective])
             perspectives = perspective_type_adapter.validate_python(perspectives_yaml['available_regions'])
@@ -68,10 +154,53 @@ class TestMpicCoordinatorService:
 
     @staticmethod
     def create_perspectives_config_dict() -> dict[str, PerspectiveEndpoints]:
+        # configure 6 target perspectives
         perspectives_as_dict = {
-            "test-1": PerspectiveEndpoints(caa_endpoint_info=PerspectiveEndpointInfo(url="http://caa1.example.com/caa"),
-                                           dcv_endpoint_info=PerspectiveEndpointInfo(url="http://dcv1.example.com/dcv")),
-            "test-2": PerspectiveEndpoints(caa_endpoint_info=PerspectiveEndpointInfo(url="http://caa2.example.com/caa"),
-                                           dcv_endpoint_info=PerspectiveEndpointInfo(url="http://dcv2.example.com/dcv"))
+            f"test-{i}": PerspectiveEndpoints(caa_endpoint_info=PerspectiveEndpointInfo(url=f"http://caa{i}.example.com/caa"),
+                                              dcv_endpoint_info=PerspectiveEndpointInfo(url=f"http://dcv{i}.example.com/dcv"))
+            for i in range(1, 7)  # 1-6
         }
         return perspectives_as_dict
+
+    # noinspection PyUnusedLocal,PyShadowingNames
+    def create_successful_api_call_response_for_dcv_check(self, url, timeout, headers, json):
+        # json arg in requests.post() is a "json serializable object" (dict) rather than an actual json string
+        check_request = DcvCheckRequest.model_validate(json)
+        # hijacking the value of 'perspective_code' to verify that the right arguments got passed to the call
+        expected_response_body = DcvCheckResponse(
+            perspective_code=check_request.domain_or_ip_target,
+            check_passed=True, details=DcvDnsCheckResponseDetails(
+                validation_method=DcvValidationMethod.ACME_DNS_01
+            )
+        )
+        expected_response = TestMpicCoordinatorService.create_mock_response(
+            200, expected_response_body.model_dump_json()
+        )
+        return expected_response
+
+    @staticmethod
+    def create_mock_response(status_code: int, content: str, kwargs: dict = None):
+        response = Response()
+        response.status_code = status_code
+        response.raw = BytesIO(content.encode('utf-8'))  # code under test reads from response.text
+        if kwargs is not None:
+            for k, v in kwargs.items():
+                setattr(response, k, v)
+        return response
+
+    @staticmethod
+    def create_caa_mpic_response():
+        caa_request = ValidMpicRequestCreator.create_valid_caa_mpic_request()
+        return MpicCaaResponse(
+            request_orchestration_parameters=caa_request.orchestration_parameters,
+            actual_orchestration_parameters=MpicEffectiveOrchestrationParameters(
+                perspective_count=3, quorum_count=2, attempt_count=1
+            ),
+            is_valid=True,
+            perspectives=[],
+            caa_check_parameters=caa_request.caa_check_parameters
+        )
+
+
+if __name__ == '__main__':
+    pytest.main()

--- a/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
@@ -1,8 +1,21 @@
+import pytest
+
 from mpic_dcv_checker_service.main import MpicDcvCheckerService
 
 
 # noinspection PyMethodMayBeStatic
-class TestMpicDcvCheckerServiceLambda:
+class TestMpicDcvCheckerService:
+    @staticmethod
+    @pytest.fixture(scope='class')
+    def set_env_variables():
+        envvars = {
+            'AWS_REGION': 'us-east-1',
+        }
+        with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
+            for k, v in envvars.items():
+                class_scoped_monkeypatch.setenv(k, v)
+            yield class_scoped_monkeypatch  # restore the environment afterward
+
     def service__should_read_in_environment_configuration_through_config_file(self):
         service = MpicDcvCheckerService()
         # it'll read in the placeholder values in the config files -- that's acceptable for this particular test

--- a/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
@@ -1,6 +1,18 @@
+import time
 import pytest
 
-from mpic_dcv_checker_service.main import MpicDcvCheckerService
+from fastapi import status
+from fastapi.testclient import TestClient
+from open_mpic_core.common_domain.check_response import DcvCheckResponse
+from open_mpic_core.common_domain.check_response_details import DcvHttpCheckResponseDetails
+from open_mpic_core.common_domain.enum.dcv_validation_method import DcvValidationMethod
+from open_mpic_core.common_domain.validation_error import MpicValidationError
+from open_mpic_core_test.test_util.valid_check_creator import ValidCheckCreator
+
+from mpic_dcv_checker_service.main import MpicDcvCheckerService, app
+
+
+client = TestClient(app)
 
 
 # noinspection PyMethodMayBeStatic
@@ -21,3 +33,40 @@ class TestMpicDcvCheckerService:
         # it'll read in the placeholder values in the config files -- that's acceptable for this particular test
         # note: this test is semi-invalidated by other tests that check this value because it's a global load
         assert service.perspective_code == 'PERSPECTIVE_NAME_CODE_STRING'
+
+    # noinspection PyMethodMayBeStatic
+    def service__should_do_dcv_check_using_configured_dcv_checker(self, set_env_variables, mocker):
+        dcv_check_request = ValidCheckCreator.create_valid_http_check_request()
+        mock_dcv_response = TestMpicDcvCheckerService.create_dcv_check_response()
+        mocker.patch('open_mpic_core.mpic_dcv_checker.mpic_dcv_checker.MpicDcvChecker.check_dcv',
+                     return_value=mock_dcv_response)
+        response = client.post('/dcv', json=dcv_check_request.model_dump())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == mock_dcv_response.model_dump()
+
+    @pytest.mark.parametrize('error_type, error_message, expected_status_code', [
+        ('404', 'Not Found', status.HTTP_404_NOT_FOUND),
+        ('No Answer', 'The DNS response does not contain an answer to the question', status.HTTP_500_INTERNAL_SERVER_ERROR)
+    ])
+    def service__should_return_appropriate_status_code_given_dcv_related_errors_in_response(
+            self, error_type: str, error_message: str, expected_status_code: int, set_env_variables, mocker):
+        mock_dcv_response = TestMpicDcvCheckerService.create_dcv_check_response()
+        mock_dcv_response.check_passed = False
+        mock_dcv_response.errors = [(MpicValidationError(error_type=error_type, error_message=error_message))]
+        mocker.patch('open_mpic_core.mpic_dcv_checker.mpic_dcv_checker.MpicDcvChecker.check_dcv',
+                     return_value=mock_dcv_response)
+        dcv_check_request = ValidCheckCreator.create_valid_http_check_request()
+        response = client.post('/dcv', json=dcv_check_request.model_dump())
+        assert response.status_code == expected_status_code
+        assert response.json() == mock_dcv_response.model_dump()
+
+    @staticmethod
+    def create_dcv_check_response():
+        return DcvCheckResponse(perspective_code='us-east-1', check_passed=True,
+                                details=DcvHttpCheckResponseDetails(
+                                    validation_method=DcvValidationMethod.WEBSITE_CHANGE_V2
+                                ), timestamp_ns=time.time_ns())
+
+
+if __name__ == '__main__':
+    pytest.main()


### PR DESCRIPTION
We have 99% code coverage now, Merry Christmas ^^

Added logic (equivalent to the AWS Lambda wrapper logic, no more no less really) around error handling. It's likely incomplete in both wrapper projects, though I hope to discover precisely in what way through some exploratory testing.

Also moved a test yaml to a `resources` folder under `tests`, in order to not have content that's specifically coupled to tests leak into the `src` directory. 