### PR TITLE
new compose file that uses build not images for local changes

### DIFF
--- a/deployment-examples/local-docker-compose/compose.build.example.yaml
+++ b/deployment-examples/local-docker-compose/compose.build.example.yaml
@@ -1,0 +1,130 @@
+name: open-mpic
+
+services:
+  dcv_checker_1:
+    build:
+      context: ../../api-implementation
+      args:
+        SERVICE_PATH: "src/mpic_dcv_checker_service"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dcv1.rule=Host(`localhost`) && PathPrefix(`/dcv-checker-1`)"
+      - "traefik.http.services.dcv1.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.strip_dcv1.stripprefix.prefixes=/dcv-checker-1"
+      - "traefik.http.routers.dcv1.middlewares=strip_dcv1@docker"
+    configs:
+      - source: dcv_config_1
+        target: /app/config/app.conf
+      - source: log_config
+        target: /app/config/log_config.yaml
+
+  dcv_checker_2:
+    build:
+      context: ../../api-implementation
+      args:
+        SERVICE_PATH: "src/mpic_dcv_checker_service"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dcv2.rule=Host(`localhost`) && PathPrefix(`/dcv-checker-2`)"
+      - "traefik.http.services.dcv2.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.strip_dcv2.stripprefix.prefixes=/dcv-checker-2"
+      - "traefik.http.routers.dcv2.middlewares=strip_dcv2@docker"
+    configs:
+      - source: dcv_config_2
+        target: /app/config/app.conf
+      - source: log_config
+        target: /app/config/log_config.yaml
+
+  coordinator:
+    build:
+      context: ../../api-implementation
+      args:
+        SERVICE_PATH: "src/mpic_coordinator_service"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coordinator.rule=Host(`localhost`) && PathPrefix(`/mpic-coordinator`)"
+      - "traefik.http.services.coordinator.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.strip_coordinator.stripprefix.prefixes=/mpic-coordinator"
+      - "traefik.http.routers.coordinator.middlewares=strip_coordinator@docker"
+    configs:
+      - source: coordinator_config
+        target: /app/config/app.conf
+      - source: log_config
+        target: /app/config/log_config.yaml
+    volumes:
+      - ./resources:/app/resources
+
+  caa_checker_1:
+    build:
+      context: ../../api-implementation
+      args:
+        SERVICE_PATH: "src/mpic_caa_checker_service"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.caa1.rule=Host(`localhost`) && PathPrefix(`/caa-checker-1`)"
+      - "traefik.http.services.caa1.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.strip_caa1.stripprefix.prefixes=/caa-checker-1"
+      - "traefik.http.routers.caa1.middlewares=strip_caa1@docker"
+    configs:
+      - source: caa_config_1
+        target: /app/config/app.conf
+      - source: log_config
+        target: /app/config/log_config.yaml
+
+  caa_checker_2:
+    build:
+      context: ../../api-implementation
+      args:
+        SERVICE_PATH: "src/mpic_caa_checker_service"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.caa2.rule=Host(`localhost`) && PathPrefix(`/caa-checker-2`)"
+      - "traefik.http.services.caa2.loadbalancer.server.port=80"
+      - "traefik.http.middlewares.strip_caa2.stripprefix.prefixes=/caa-checker-2"
+      - "traefik.http.routers.caa2.middlewares=strip_caa2@docker"
+    configs:
+      - source: caa_config_2
+        target: /app/config/app.conf
+      - source: log_config
+        target: /app/config/log_config.yaml
+
+  traefik:
+    image: traefik:v2.9
+    command:
+      - --api.insecure=true # Don't do this in production!
+      - --providers.docker=true
+      - --api.dashboard=true
+      - --providers.docker.exposedbydefault=false
+    ports:
+      # The HTTP port
+      - "8000:80"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+configs:
+  dcv_config_1:
+    content: |
+      code="example-region-1"
+      verify_ssl=False
+  dcv_config_2:
+    content: |
+      code="example-region-2"
+      verify_ssl=False
+  caa_config_1:
+    content: |
+      code="example-region-1"
+      default_caa_domains="example.com|example.org"
+  caa_config_2:
+    content: |
+      code="example-region-2"
+      default_caa_domains="example.com|example.org"
+  coordinator_config:
+    content: |
+      perspectives={"example-region-1":{"caa_endpoint_info":{"url":"http://caa_checker_1:80/caa"},"dcv_endpoint_info":{"url":"http://dcv_checker_1:80/dcv"}},"example-region-2":{"caa_endpoint_info":{"url":"http://caa_checker_2:80/caa"},"dcv_endpoint_info":{"url":"http://dcv_checker_2:80/dcv"}}}
+      default_perspective_count=2
+      absolute_max_attempts=2
+      hash_secret=hash_secret
+  log_config:
+    file: ./common_config/log_config.yaml


### PR DESCRIPTION
@sciros I realized the existing compose file could be trivially changed to use build instead of images. I find this helpful when testing local changes like the trace logging. I simply put this as an alternate example file. Let me know your thoughts.