### PR TITLE
Add Trivy vulnerability scanner to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ steps.push.outputs.digest }}
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,17 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Convert digest format
+        id: format-digest
+        run: |
+          DIGEST="${{ steps.push.outputs.digest }}"
+          FORMATTED_DIGEST=$(echo "$DIGEST" | sed 's/:/-/g')  # Replace : with -
+          echo "formatted_digest=$FORMATTED_DIGEST" >> $GITHUB_OUTPUT
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ steps.push.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ steps.format-digest.outputs.formatted_digest }}
           format: "table"
           exit-code: "1"
           ignore-unfixed: true


### PR DESCRIPTION
Integrate the Trivy vulnerability scanner into the CI workflow to enhance security by identifying vulnerabilities in OS and library dependencies.