### PR TITLE
Externalized Uvicorn config. Added smoke tests. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files that should have .examples. in the repository but are otherwise deployment specific configuration
 deployment-examples/local-docker-compose/resources/available_perspectives.yaml
 deployment-examples/local-docker-compose/common_config/log_config.yaml
+deployment-examples/local-docker-compose/common_config/uvicorn_config.yaml
 deployment-examples/local-docker-compose/compose.yaml
 deployment-examples/amazon-ec2/config.yaml
 deployment-examples/*/*generated.tf

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -26,4 +26,4 @@ COPY ${SERVICE_PATH} .
 RUN hatch env create production
 
 # Run the service using uvicorn with the production environment
-CMD ["hatch", "env", "run", "-e", "production", "--", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--proxy-headers", "--log-config", "/app/config/log_config.yaml"]
+CMD ["hatch", "env", "run", "-e", "production", "--", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--proxy-headers", "--log-config", "/app/config/log_config.yaml", "--timeout-keep-alive", "60"]

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -25,5 +25,19 @@ COPY ${SERVICE_PATH} .
 # This will install the Python version specified in pyproject.toml
 RUN hatch env create production
 
-# Run the service using uvicorn with the production environment
-CMD ["hatch", "env", "run", "-e", "production", "--", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--proxy-headers", "--log-config", "/app/config/log_config.yaml", "--timeout-keep-alive", "60"]
+# Install additional dependencies
+RUN hatch env run -e production -- pip install PyYAML
+
+# Create config directory
+RUN mkdir -p /app/config
+
+# Copy configuration files and scripts
+COPY uvicorn_config.yaml /app/config/
+COPY run_uvicorn.py /app/
+COPY docker-entrypoint.sh /app/
+
+# Make entrypoint script executable
+RUN chmod +x /app/docker-entrypoint.sh
+
+# Set the entrypoint script
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/api-implementation/README.md
+++ b/api-implementation/README.md
@@ -10,7 +10,7 @@ docker build -t mpiccaachecker . --build-arg SERVICE_PATH=src/mpic_caa_checker_s
 MPIC CAA Checker
 ```bash
 docker build -t mpicdcvchecker . --build-arg SERVICE_PATH=src/mpic_dcv_checker_service --progress=plain
-``` 
+```
 
 #### Local Testing: running Docker containers with Docker Compose
 (See `/deployment-examples/local-docker-compose/README.md` for more information)

--- a/api-implementation/docker-entrypoint.sh
+++ b/api-implementation/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Execute the Python script
+exec hatch env run -e production -- python /app/run_uvicorn.py

--- a/api-implementation/run_uvicorn.py
+++ b/api-implementation/run_uvicorn.py
@@ -28,6 +28,10 @@ def main():
     config.setdefault('log_config', '/app/config/log_config.yaml')
     config.setdefault('timeout_keep_alive', 60)
 
+    # Get a default number of workers based on cpu count
+    workers = (os.cpu_count() * 2 + 1) if os.cpu_count() else 1
+    config.setdefault('workers', workers)
+
     # Start uvicorn with the configured parameters
     uvicorn.run(
         "main:app",
@@ -36,7 +40,7 @@ def main():
         proxy_headers=config['proxy_headers'],
         log_config=config['log_config'],
         timeout_keep_alive=config['timeout_keep_alive'],
-        workers=config.get('workers', 1),
+        workers=config['workers'],
         reload=config.get('reload', False)
     )
 

--- a/api-implementation/run_uvicorn.py
+++ b/api-implementation/run_uvicorn.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import yaml
+from typing import Dict, Any
+
+
+def load_config(config_path: str) -> Dict[str, Any]:
+    """Load uvicorn configuration from YAML file."""
+    if not os.path.exists(config_path):
+        print(f"Config file not found at {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path, 'r') as f:
+        return yaml.safe_load(f)
+
+
+def main():
+    # Default config path, can be overridden by environment variable
+    config_path = os.getenv('UVICORN_CONFIG_PATH', '/app/config/uvicorn_config.yaml')
+    config = load_config(config_path)
+
+    import uvicorn
+
+    # Ensure required config values have defaults
+    config.setdefault('host', '0.0.0.0')
+    config.setdefault('port', 80)
+    config.setdefault('proxy_headers', True)
+    config.setdefault('log_config', '/app/config/log_config.yaml')
+    config.setdefault('timeout_keep_alive', 60)
+
+    # Start uvicorn with the configured parameters
+    uvicorn.run(
+        "main:app",
+        host=config['host'],
+        port=config['port'],
+        proxy_headers=config['proxy_headers'],
+        log_config=config['log_config'],
+        timeout_keep_alive=config['timeout_keep_alive'],
+        workers=config.get('workers', 1),
+        reload=config.get('reload', False)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/api-implementation/src/mpic_caa_checker_service/main.py
+++ b/api-implementation/src/mpic_caa_checker_service/main.py
@@ -13,12 +13,12 @@ from open_mpic_core import get_logger
 
 # 'config' directory should be a sibling of the directory containing this file
 config_path = Path(__file__).parent / "config" / "app.conf"
-load_dotenv(config_path)
 logger = get_logger(__name__)
 
 
 class MpicCaaCheckerService:
     def __init__(self):
+        load_dotenv(config_path)
         # FIXME warn on default_caa_domain_list None or empty
         self.default_caa_domain_list = os.environ["default_caa_domains"].split("|")
         self.caa_checker = MpicCaaChecker(self.default_caa_domain_list)

--- a/api-implementation/src/mpic_coordinator_service/config/app.conf
+++ b/api-implementation/src/mpic_coordinator_service/config/app.conf
@@ -2,3 +2,5 @@ perspectives=PERSPECTIVES_CONFIGURATION_JSON
 default_perspective_count=DEFAULT_PERSPECTIVE_COUNT_INT
 absolute_max_attempts=ABSOLUTE_MAX_ATTEMPTS_INT
 hash_secret=HASH_SECRET_STRING
+http_client_timeout_seconds=10
+http_client_keepalive_timeout_seconds=60

--- a/api-implementation/src/mpic_dcv_checker_service/config/app.conf
+++ b/api-implementation/src/mpic_dcv_checker_service/config/app.conf
@@ -1,2 +1,2 @@
 verify_ssl=True
-http_client_timeout=30
+http_client_timeout_seconds=35

--- a/api-implementation/src/mpic_dcv_checker_service/main.py
+++ b/api-implementation/src/mpic_dcv_checker_service/main.py
@@ -13,16 +13,16 @@ from open_mpic_core import get_logger
 
 # 'config' directory should be a sibling of the directory containing this file
 config_path = Path(__file__).parent / "config" / "app.conf"
-load_dotenv(config_path)
 logger = get_logger(__name__)
 
 
 class MpicDcvCheckerService:
     def __init__(self):
+        load_dotenv(config_path)
         self.verify_ssl = "verify_ssl" not in os.environ or os.environ["verify_ssl"] == "True"
         self.http_client_timeout_seconds = (
-            os.environ["http_client_timeout_seconds"]
-            if "http_client_timeout_seconds" in os.environ and float(os.environ["http_client_timeout_seconds"])
+            float(os.environ["http_client_timeout_seconds"])
+            if "http_client_timeout_seconds" in os.environ
             else 30
         )
         self.dcv_checker = MpicDcvChecker(

--- a/api-implementation/tests/integration/test_smoke_deployed_mpic_api.py
+++ b/api-implementation/tests/integration/test_smoke_deployed_mpic_api.py
@@ -1,0 +1,71 @@
+import json
+import sys
+import pytest
+import time
+
+from pydantic import TypeAdapter
+
+from open_mpic_core import (
+    CaaCheckParameters,
+    DcvAcmeDns01ValidationParameters,
+)
+from open_mpic_core import CertificateType
+from open_mpic_core import MpicCaaRequest, MpicDcvRequest, MpicResponse
+from open_mpic_core import MpicRequestOrchestrationParameters
+from open_mpic_core import MpicCaaResponse, PerspectiveResponse
+
+import testing_api_client
+
+
+MPIC_REQUEST_PATH = "mpic"
+
+
+# noinspection PyMethodMayBeStatic
+@pytest.mark.integration
+class TestDeployedMpicApi:
+    @classmethod
+    def setup_class(cls):
+        cls.mpic_response_adapter = TypeAdapter(MpicResponse)
+
+    @pytest.fixture(scope="class")
+    def api_client(self):
+        with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
+            # blank out argv except first param; arg parser doesn't expect pytest args
+            class_scoped_monkeypatch.setattr(sys, "argv", sys.argv[:1])
+            api_client = testing_api_client.TestingApiClient()
+            yield api_client
+            api_client.close()
+
+    def api__should_return_200_and_passed_corroboration_for_successful_caa_check(self, api_client):
+        request = MpicCaaRequest(
+            trace_identifier=f"test_trace_id_{time.time()}",
+            domain_or_ip_target="example.com",
+            orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=2, quorum_count=2),
+            caa_check_parameters=CaaCheckParameters(
+                certificate_type=CertificateType.TLS_SERVER, caa_domains=["mozilla.com"]
+            ),
+        )
+
+        print("\nRequest:\n", json.dumps(request.model_dump(), indent=4))  # pretty print request body
+        response = api_client.post(MPIC_REQUEST_PATH, json.dumps(request.model_dump()))
+        self.validate_200_response(response)
+
+    def api__should_return_200_and_successful_corroboration_for_valid_dns_01_validation(self, api_client):
+        request = MpicDcvRequest(
+            trace_identifier=f"test_trace_id_{time.time()}",
+            domain_or_ip_target='dns-01.integration-testing.open-mpic.org',
+            orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=2, quorum_count=2),
+            dcv_check_parameters=DcvAcmeDns01ValidationParameters(
+                key_authorization_hash="7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
+            ),
+        )
+
+        print("\nRequest:\n", json.dumps(request.model_dump(), indent=4))  # pretty print request body
+        response = api_client.post(MPIC_REQUEST_PATH, json.dumps(request.model_dump()))
+        self.validate_200_response(response)
+
+    def validate_200_response(self, response):
+        assert response.status_code == 200
+        mpic_response = self.mpic_response_adapter.validate_json(response.text)
+        print("\nResponse:\n", json.dumps(mpic_response.model_dump(), indent=4))
+        assert mpic_response.is_valid is True

--- a/api-implementation/tests/integration/test_smoke_deployed_mpic_api.py
+++ b/api-implementation/tests/integration/test_smoke_deployed_mpic_api.py
@@ -12,7 +12,6 @@ from open_mpic_core import (
 from open_mpic_core import CertificateType
 from open_mpic_core import MpicCaaRequest, MpicDcvRequest, MpicResponse
 from open_mpic_core import MpicRequestOrchestrationParameters
-from open_mpic_core import MpicCaaResponse, PerspectiveResponse
 
 import testing_api_client
 

--- a/api-implementation/tests/unit/conftest.py
+++ b/api-implementation/tests/unit/conftest.py
@@ -2,8 +2,25 @@
 import logging
 from io import StringIO
 import pytest
+import os
 from open_mpic_core import TRACE_LEVEL
 
+
+@pytest.fixture(autouse=True)
+def clear_env_vars():
+    """Clear environment variables before each test to prevent cross-test contamination."""
+    # Store original environment
+    original_env = dict(os.environ)
+
+    # Clear all environment variables that might affect tests
+    for key in list(os.environ.keys()):
+        del os.environ[key]
+
+    yield
+
+    # Restore original environment after test
+    os.environ.clear()
+    os.environ.update(original_env)
 
 
 @pytest.fixture(autouse=True)
@@ -16,7 +33,6 @@ def setup_logging():
     log_output = StringIO()  # to be able to inspect what gets logged
     handler = logging.StreamHandler(log_output)
     handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
-
 
     # Configure fresh logging
     logging.basicConfig(

--- a/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_dcv_checker_service.py
@@ -17,6 +17,8 @@ from mpic_dcv_checker_service.main import app
 
 # noinspection PyMethodMayBeStatic
 class TestMpicDcvCheckerService:
+
+
     # noinspection PyMethodMayBeStatic
     def service__should_do_dcv_check_using_configured_dcv_checker(self, mocker):
         dcv_check_request = ValidCheckCreator.create_valid_http_check_request()
@@ -87,7 +89,7 @@ class TestMpicDcvCheckerService:
             re.match(r"^\d+\.\d+\.\d+", config[key])
             for key in ["app_version", "open_mpic_api_spec_version", "mpic_core_version"]
         )
-        assert config["http_client_timeout_seconds"] == 30
+        assert config["http_client_timeout_seconds"] == 35  # default in app.conf file
         assert config["verify_ssl"] is True
 
     @staticmethod

--- a/api-implementation/uvicorn_config.yaml
+++ b/api-implementation/uvicorn_config.yaml
@@ -1,0 +1,13 @@
+# Default Uvicorn configuration
+
+# Network settings
+host: "0.0.0.0"
+port: 80
+
+# Server behavior
+workers: 1
+proxy_headers: true
+timeout_keep_alive: 60
+
+# Logging
+log_config: "/app/config/log_config.yaml"

--- a/deployment-examples/local-docker-compose/common_config/uvicorn_config_example.yaml
+++ b/deployment-examples/local-docker-compose/common_config/uvicorn_config_example.yaml
@@ -1,0 +1,29 @@
+# Example Uvicorn configuration with explanations
+# Copy this file and adjust values according to your needs
+
+# Network settings
+# host: Interface to bind to
+# port: Port number for the service
+host: "0.0.0.0"
+port: 80
+
+# Server behavior
+# workers: Number of worker processes. Recommended: 2 × NUM_CORES + 1
+# reload: Enable auto-reload on code changes (development only)
+# proxy_headers: Enable processing of proxy headers
+# timeout_keep_alive: Timeout for keep-alive connections
+workers: 1
+# reload: false  # mutually exclusive with workers parameter
+proxy_headers: true
+timeout_keep_alive: 60
+
+# Logging
+# log_config: Path to the logging configuration file
+log_config: "/app/config/log_config.yaml"
+
+# Additional settings you might want to configure:
+# - ssl_keyfile: SSL key file path
+# - ssl_certfile: SSL certificate file path
+# - backlog: Maximum number of connections to hold in backlog
+# - limit_concurrency: Maximum number of concurrent connections
+# - limit_max_requests: Maximum number of requests to handle before restarting worker

--- a/deployment-examples/local-docker-compose/compose.build.example.yaml
+++ b/deployment-examples/local-docker-compose/compose.build.example.yaml
@@ -17,6 +17,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   dcv_checker_2:
     build:
@@ -34,6 +36,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   coordinator:
     build:
@@ -51,6 +55,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
     volumes:
       - ./resources:/app/resources
 
@@ -70,6 +76,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   caa_checker_2:
     build:
@@ -87,6 +95,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   traefik:
     image: traefik:v2.9
@@ -127,3 +137,5 @@ configs:
       http_client_timeout_seconds=5
   log_config:
     file: ./common_config/log_config.yaml
+  uvicorn_config:
+    file: ./common_config/uvicorn_config.yaml

--- a/deployment-examples/local-docker-compose/compose.example.yaml
+++ b/deployment-examples/local-docker-compose/compose.example.yaml
@@ -14,6 +14,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   dcv_checker_2:
     image: ghcr.io/open-mpic/dcv_checker:latest
@@ -28,6 +30,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   coordinator:
     image: ghcr.io/open-mpic/coordinator:latest
@@ -42,6 +46,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
     volumes:
       - ./resources:/app/resources
 
@@ -58,6 +64,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   caa_checker_2:
     image: ghcr.io/open-mpic/caa_checker:latest
@@ -72,6 +80,8 @@ services:
         target: /app/config/app.conf
       - source: log_config
         target: /app/config/log_config.yaml
+      - source: uvicorn_config
+        target: /app/config/uvicorn_config.yaml
 
   traefik:
     image: traefik:v2.9
@@ -112,3 +122,5 @@ configs:
       http_client_timeout_seconds=5
   log_config:
     file: ./common_config/log_config.yaml
+  uvi_config:
+    file: ./common_config/uvicorn_config.yaml


### PR DESCRIPTION
Externalized how Uvicorn gets configured so that can be set at runtime via a yaml config file, same as log config.
Added two integration smoke tests in a separate file, one doing CAA one doing DCV.
The externalized configuration now allows for connection `timeout-keep-alive` and `workers` to be tweaked in order to optimize performance. 