### PR TITLE
changed infra cache to 1 ttl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,3 +110,83 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  Image-Build-Unbound:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        service: [unbound]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Authenticate to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          tags: |
+            # set timestamp tag
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # This step sets up QEMU for cross-platform builds.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # This step sets up Docker Buildx for multi-platform builds.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # Built unbound image.
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          context: unbound
+          file: unbound/Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: unbound
+          platforms: linux/amd64,linux/arm64
+          file: unbound/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/deployment-examples/local-docker-compose/unbound_config/unbound.conf.example
+++ b/deployment-examples/local-docker-compose/unbound_config/unbound.conf.example
@@ -19,6 +19,9 @@ server:
     #cache-min-ttl: 300
     cache-min-ttl: 1
 
+    # Reduce the infra host cache TTL to mitigate nameserver forcing attacks.
+    infra-host-ttl: 1
+
     # Set the working directory for the program.
     directory: "/opt/unbound/etc/unbound"
 
@@ -76,7 +79,7 @@ server:
     # If you want to log to a file, use:
     # logfile: /opt/unbound/etc/unbound/unbound.log
     # Set log location (using /dev/null further limits logging)
-    logfile: ""
+    logfile: /dev/null
 
     # Set logging level
     # Level 0: No verbosity, only errors.

--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+
+# Dist/package upgrade
+RUN apt-get update && apt-get dist-upgrade -y
+
 # Create the _unbound user
 RUN useradd -r -s /usr/sbin/nologin -d /var/lib/unbound -M _unbound
 
@@ -36,10 +40,10 @@ RUN unbound-anchor -a "/opt/unbound/etc/unbound/var/root.key" || true # exit cod
 
 # Create a simple startup script
 RUN echo '#!/bin/sh\n\
-# Start Unbound in foreground mode\n\
-exec /usr/sbin/unbound -d -c /opt/unbound/etc/unbound/unbound.conf\n\
-' > /start.sh && \
-chmod +x /start.sh
+    # Start Unbound in foreground mode\n\
+    exec /usr/sbin/unbound -d -c /opt/unbound/etc/unbound/unbound.conf\n\
+    ' > /start.sh && \
+    chmod +x /start.sh
 
 # Expose DNS ports
 EXPOSE 53/tcp 53/udp

--- a/unbound/unbound.conf
+++ b/unbound/unbound.conf
@@ -19,6 +19,9 @@ server:
     #cache-min-ttl: 300
     cache-min-ttl: 1
 
+    # Reduce the infra host cache TTL to mitigate nameserver forcing attacks.
+    infra-host-ttl: 1
+
     # Set the working directory for the program.
     directory: "/opt/unbound/etc/unbound"
 


### PR DESCRIPTION
I was running some integration tests and I accidentally ran a test where the integration zone NS happened to be offline. Obviously the integration tests failed. However, quite to my surprise, even after bringing the server back up the tests kept failing.

This made me remember that unbound has two caches: a record cache (e.g., domain in A ...) and an infrastructure cache (e.g., I talked to NS1.example.com and it hand an RTT of 10ms or it was offline). What I believe happened was unbound cached the nameserver being offline and then kept throwing NO Nameserver errors without actually rechecking the nameservers.

I noticed in the unbound documentation this cache is actually configurable. I set infra-host-ttl: 1 (seconds) to essentially disable the infra host cache. Note that this also mitigates a nameserver forcing attack that has been studied against CAs: https://dl.acm.org/doi/10.1145/3460120.3484815 

While this is the most secure setting (as it forces unbound to always select a nameserver at random) it may have a performance hit. I personally think the security gain is worth it and we already have a no caching policy for RRSETs, so this seems consistent.