### PR TITLE
Update README and scripts to update to latest api

### DIFF
--- a/deployment-examples/kubernetes/open-mpic/README.md
+++ b/deployment-examples/kubernetes/open-mpic/README.md
@@ -45,11 +45,8 @@ curl -H 'Content-Type: application/json' \
   "check_type": "dcv",
   "domain_or_ip_target": "dns-01.integration-testing.open-mpic.org",
   "dcv_check_parameters": {
-
-  "validation_details": {
     "validation_method": "acme-dns-01",
-    "key_authorization": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
-    }
+    "key_authorization_hash": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
   }
 }' \
       -X POST \
@@ -62,11 +59,8 @@ hey -n 500 -m POST -H "Content-Type: application/json" -d '{
   "check_type": "dcv",
   "domain_or_ip_target": "dns-01.integration-testing.open-mpic.org",
   "dcv_check_parameters": {
-
-  "validation_details": {
     "validation_method": "acme-dns-01",
-    "key_authorization": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
-    }
+    "key_authorization_hash": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
   }
 }' "http://localhost/mpic"
 ```

--- a/deployment-examples/kubernetes/scripts/generate-traffic.sh
+++ b/deployment-examples/kubernetes/scripts/generate-traffic.sh
@@ -9,10 +9,7 @@ hey -n 500 -m POST -H "Content-Type: application/json" -d '{
   "check_type": "dcv",
   "domain_or_ip_target": "dns-01.integration-testing.open-mpic.org",
   "dcv_check_parameters": {
-
-  "validation_details": {
     "validation_method": "acme-dns-01",
-    "key_authorization": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
+    "key_authorization_hash": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
     }
-  }
 }' "http://localhost/mpic"

--- a/deployment-examples/local-docker-compose/README.md
+++ b/deployment-examples/local-docker-compose/README.md
@@ -57,11 +57,8 @@ curl -H 'Content-Type: application/json' \
   "check_type": "dcv",
   "domain_or_ip_target": "dns-01.integration-testing.open-mpic.org",
   "dcv_check_parameters": {
-
-  "validation_details": {
     "validation_method": "acme-dns-01",
-    "key_authorization": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
-    }
+    "key_authorization_hash": "7FwkJPsKf-TH54wu4eiIFA3nhzYaevsL7953ihy-tpo"
   }
 }' \
       -X POST \


### PR DESCRIPTION
This pull request includes updates to several deployment example files to change the `key_authorization` field to `key_authorization_hash`. Additionally I've updated the request to remove the `validation_details` as it is no longer used.

Changes to deployment examples:

* [`deployment-examples/kubernetes/open-mpic/README.md`](diffhunk://#diff-0a7918c4e8fdb84fe8aca1ffb6a037cbd303afca892fabbfa51f08e9f1212f70L48-R49): Updated the `key_authorization` field to `key_authorization_hash` in the JSON payload for the `curl` and `hey` commands. [[1]](diffhunk://#diff-0a7918c4e8fdb84fe8aca1ffb6a037cbd303afca892fabbfa51f08e9f1212f70L48-R49) [[2]](diffhunk://#diff-0a7918c4e8fdb84fe8aca1ffb6a037cbd303afca892fabbfa51f08e9f1212f70L65-R63)
* [`deployment-examples/kubernetes/scripts/generate-traffic.sh`](diffhunk://#diff-3590651d8b4e582cf5f3557e60208047991932d44554b48543b4b538c48f4cdaL12-R13): Modified the `key_authorization` field to `key_authorization_hash` in the JSON payload for the `hey` command.
* [`deployment-examples/local-docker-compose/README.md`](diffhunk://#diff-a0b159dac41115cecc022c17b5be2557e12aa60e6ebf5f219fcb264c68164672L60-R61): Changed the `key_authorization` field to `key_authorization_hash` in the JSON payload for the `curl` command.