### PR TITLE
Added slightly richer configz content

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Only use valid, real RIR codes (e.g., "ARIN") in this file.
 If this file is improperly configured, the coordinator cannot reliably enforce a valid set of corroborating perspectives
 and may return results that are not valid to allow issuance. Invalid RIR codes will result in a runtime error.
 
+List of valid RIR codes:
+- ARIN
+- RIPE NCC
+- APNIC
+- LACNIC
+- AFRINIC
+
+The application in case-insensitive for RIR codes, but be sure to include the space if using "RIPE NCC".
+
 Modify the yaml file to add or remove perspectives as needed.
 
 It is recommended that the `available_perspectives.yaml` file be kept in sync with the perspectives configured in the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,32 @@ The repository contains three containers:
 
 Different deployments (see deployment examples) will wrap deploy these containers indifferent contexts (e.g., docker compose, kubernetes) and may use various network architectures (e.g., public Internet, VPN, service mesh network) to facilitate calls between the containers. The containers may be placed beyond ingress and load balancing to provide optimal uptime and scaling. This is recommended for a production deployment.
 
+## Configuration Notes
+
+### available_perspectives.yaml
+Each deployment example utilizes an `available_perspectives.yaml` resource file in some form.
+
+This yaml file lists all the perspectives to which you are deploying your CAA and DCV checkers. It is consumed by
+the Coordinator service to determine which perspectives can be used for each check. It is also used by the
+Coordinator to determine whether a given set of corroborating perspectives is _valid_ by inspecting the RIR (Regional
+Internet Registry) that is specified for each perspective.
+
+Only use valid, real RIR codes (e.g., "ARIN") in this file.
+If this file is improperly configured, the coordinator cannot reliably enforce a valid set of corroborating perspectives
+and may return results that are not valid to allow issuance. Invalid RIR codes will result in a runtime error.
+
+Modify the yaml file to add or remove perspectives as needed.
+
+It is recommended that the `available_perspectives.yaml` file be kept in sync with the perspectives configured in the
+`compose.yaml` file (i.e., the perspectives to which you have deployed a checker).
+You will not encounter errors if the yaml file defines extra perspectives to which you have not deployed a checker. 
+You will, however, encounter errors if the yaml file does not define all the perspectives to which you _have_ deployed a checker.
+
+Make sure the codes in the `available_perspectives.yaml` file correspond to the perspective codes used to specify CAA 
+and DCV checker URLs in the `compose.yaml` file (as part of coordinator configuration).
+
+Check each of the **deployment examples** for other, deployment specific configuration files and how they should be treated.
+
 ## Authentication
 
 The containers themselves **do not contain any authentication or terminate TLS**. The appropriate security model of these systems is left to the deploying CAs. To comply with the MPIC requirement of the CA/Browser Forum Baseline Requirements, **any production deployment must properly implement security**. Some example approaches are:

--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.0.1"
+version = "1.0.2"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -33,7 +33,7 @@ dependencies = [
     "fastapi[standard]>=0.115.0,<0.116.0",
     "starlette==0.45.3",
 #    "open-mpic-core @ git+https://github.com/open-mpic/open-mpic-core-python.git@ds-more-error-handling",
-    "open-mpic-core==5.5.1",
+    "open-mpic-core==5.5.2",
     "aiohttp==3.11.13",
     "uvicorn>=0.22.0,<0.23.0",
     "black==24.8.0",

--- a/api-implementation/run_uvicorn.py
+++ b/api-implementation/run_uvicorn.py
@@ -32,6 +32,9 @@ def main():
     workers = (os.cpu_count() * 2 + 1) if os.cpu_count() else 1
     config.setdefault('workers', workers)
 
+    # set OS env variable for FastAPI app to access to output runtime configuration
+    os.environ['uvicorn_server_timeout_keep_alive'] = config['timeout_keep_alive']
+
     # Start uvicorn with the configured parameters
     uvicorn.run(
         "main:app",

--- a/api-implementation/src/mpic_caa_checker_service/main.py
+++ b/api-implementation/src/mpic_caa_checker_service/main.py
@@ -62,16 +62,22 @@ async def health_check():
 async def get_config():
     current = Path(__file__).parent
     for _ in range(3):  # Try up to 3 levels up (Docker flattens the file structure a fair bit)
-        test_path = current / "pyproject.toml"
-        if test_path.exists():
-            with test_path.open(mode="rb") as file:
+        path_to_project_config = current / "pyproject.toml"
+        if path_to_project_config.exists():
+            with path_to_project_config.open(mode="rb") as file:
                 pyproject = tomllib.load(file)
+                uvicorn_server_timeout_keep_alive = (
+                    os.environ["uvicorn_server_timeout_keep_alive"]
+                    if "uvicorn_server_timeout_keep_alive" in os.environ
+                    else None
+                )
                 return {
                     "open_mpic_api_spec_version": pyproject["tool"]["api"]["spec_version"],
                     "app_version": pyproject["project"]["version"],
                     "mpic_core_version": importlib.metadata.version("open-mpic-core"),
                     "default_caa_domains": get_service().default_caa_domain_list,
                     "log_level": logger.getEffectiveLevel(),
+                    "uvicorn_server_timeout_keep_alive": uvicorn_server_timeout_keep_alive,
                 }
         current = current.parent
     raise FileNotFoundError("Could not find pyproject.toml")

--- a/api-implementation/src/mpic_coordinator_service/main.py
+++ b/api-implementation/src/mpic_coordinator_service/main.py
@@ -55,7 +55,7 @@ class MpicCoordinatorService:
         )
         self.hash_secret = os.environ["hash_secret"]
         self.http_client_timeout_seconds = (
-            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 30
+            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 5
         )
         self.http_client_keepalive_timeout_seconds = (
             float(os.environ["http_client_keepalive_timeout_seconds"])

--- a/api-implementation/src/mpic_coordinator_service/main.py
+++ b/api-implementation/src/mpic_coordinator_service/main.py
@@ -238,10 +238,15 @@ async def health_check():
 async def get_config():
     current = Path(__file__).parent
     for _ in range(3):  # Try up to 3 levels up (Docker flattens the file structure a fair bit)
-        test_path = current / "pyproject.toml"
-        if test_path.exists():
-            with test_path.open(mode="rb") as file:
+        path_to_project_config = current / "pyproject.toml"
+        if path_to_project_config.exists():
+            with path_to_project_config.open(mode="rb") as file:
                 pyproject = tomllib.load(file)
+                uvicorn_server_timeout_keep_alive = (
+                    os.environ["uvicorn_server_timeout_keep_alive"]
+                    if "uvicorn_server_timeout_keep_alive" in os.environ
+                    else None
+                )
                 return {
                     "open_mpic_api_spec_version": pyproject["tool"]["api"]["spec_version"],
                     "app_version": pyproject["project"]["version"],
@@ -251,6 +256,7 @@ async def get_config():
                     "http_client_timeout_seconds": get_service().http_client_timeout_seconds,
                     "http_client_keepalive_timeout_seconds": get_service().http_client_keepalive_timeout_seconds,
                     "log_level": logger.getEffectiveLevel(),
+                    "uvicorn_server_timeout_keep_alive": uvicorn_server_timeout_keep_alive,
                 }
         current = current.parent
     raise FileNotFoundError("Could not find pyproject.toml")

--- a/api-implementation/src/mpic_coordinator_service/main.py
+++ b/api-implementation/src/mpic_coordinator_service/main.py
@@ -51,11 +51,11 @@ class MpicCoordinatorService:
         self.all_target_perspective_codes = list(perspectives.keys())
         self.default_perspective_count = int(os.environ["default_perspective_count"])
         self.global_max_attempts = (
-            int(os.environ["absolute_max_attempts"]) if "absolute_max_attempts" in os.environ else None
+            int(os.environ["absolute_max_attempts"]) if "absolute_max_attempts" in os.environ else None  # FIXME 1?
         )
         self.hash_secret = os.environ["hash_secret"]
         self.http_client_timeout_seconds = (
-            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 5
+            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 5  # 30
         )
         self.http_client_keepalive_timeout_seconds = (
             float(os.environ["http_client_keepalive_timeout_seconds"])
@@ -249,6 +249,7 @@ async def get_config():
                     "absolute_max_attempts": get_service().global_max_attempts,
                     "default_perspective_count": get_service().default_perspective_count,
                     "http_client_timeout_seconds": get_service().http_client_timeout_seconds,
+                    "http_client_keepalive_timeout_seconds": get_service().http_client_keepalive_timeout_seconds,
                     "log_level": logger.getEffectiveLevel(),
                 }
         current = current.parent

--- a/api-implementation/src/mpic_coordinator_service/main.py
+++ b/api-implementation/src/mpic_coordinator_service/main.py
@@ -51,11 +51,11 @@ class MpicCoordinatorService:
         self.all_target_perspective_codes = list(perspectives.keys())
         self.default_perspective_count = int(os.environ["default_perspective_count"])
         self.global_max_attempts = (
-            int(os.environ["absolute_max_attempts"]) if "absolute_max_attempts" in os.environ else None  # FIXME 1?
+            int(os.environ["absolute_max_attempts"]) if "absolute_max_attempts" in os.environ else None
         )
         self.hash_secret = os.environ["hash_secret"]
         self.http_client_timeout_seconds = (
-            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 5  # 30
+            float(os.environ["http_client_timeout_seconds"]) if "http_client_timeout_seconds" in os.environ else 30
         )
         self.http_client_keepalive_timeout_seconds = (
             float(os.environ["http_client_keepalive_timeout_seconds"])

--- a/api-implementation/src/mpic_coordinator_service/resources/available_perspectives.yaml
+++ b/api-implementation/src/mpic_coordinator_service/resources/available_perspectives.yaml
@@ -2,10 +2,10 @@ available_regions:
   -
     code: "test-1"
     name: "Use something like Docker Compose or k8s to replace file with a proper configuration 1"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: []
   -
     code: "test-2"
     name: "Use something like Docker Compose or k8s to replace file with a proper configuration 2"
-    rir: "rir2"
+    rir: "ripe ncc"
     too_close_codes: []

--- a/api-implementation/src/mpic_dcv_checker_service/main.py
+++ b/api-implementation/src/mpic_dcv_checker_service/main.py
@@ -90,10 +90,15 @@ async def health_check():
 async def get_config():
     current = Path(__file__).parent
     for _ in range(3):  # Try up to 3 levels up (Docker flattens the file structure a fair bit)
-        test_path = current / "pyproject.toml"
-        if test_path.exists():
-            with test_path.open(mode="rb") as file:
+        path_to_project_config = current / "pyproject.toml"
+        if path_to_project_config.exists():
+            with path_to_project_config.open(mode="rb") as file:
                 pyproject = tomllib.load(file)
+                uvicorn_server_timeout_keep_alive = (
+                    os.environ["uvicorn_server_timeout_keep_alive"]
+                    if "uvicorn_server_timeout_keep_alive" in os.environ
+                    else None
+                )
                 return {
                     "open_mpic_api_spec_version": pyproject["tool"]["api"]["spec_version"],
                     "app_version": pyproject["project"]["version"],
@@ -101,6 +106,7 @@ async def get_config():
                     "verify_ssl": get_service().verify_ssl,
                     "http_client_timeout_seconds": get_service().http_client_timeout_seconds,
                     "log_level": logger.getEffectiveLevel(),
+                    "uvicorn_server_timeout_keep_alive": uvicorn_server_timeout_keep_alive,
                 }
         current = current.parent
     raise FileNotFoundError("Could not find pyproject.toml")

--- a/api-implementation/tests/resources/available_test_perspectives.yaml
+++ b/api-implementation/tests/resources/available_test_perspectives.yaml
@@ -3,40 +3,40 @@ available_regions:
   -
     code: "test-1"
     name: "Test Region 1"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: []
   -
     code: "test-2"
     name: "Test Region 2"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: []
   -
     code: "test-3"
     name: "Test Region 3"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: []
   -
     code: "test-4"
     name: "Test Region 4"
-    rir: "rir2"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "test-5"
     name: "Test Region 5"
-    rir: "rir2"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "test-6"
     name: "Test Region 6"
-    rir: "rir3"
+    rir: "apnic"
     too_close_codes: []
   -
     code: "test-7"
     name: "Test Region 7"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: ['test-8']
   -
     code: "test-8"
     name: "Test Region 8"
-    rir: "rir1"
+    rir: "arin"
     too_close_codes: ['test-7']

--- a/api-implementation/tests/unit/test_mpic_caa_checker_service.py
+++ b/api-implementation/tests/unit/test_mpic_caa_checker_service.py
@@ -18,7 +18,10 @@ class TestMpicCaaCheckerService:
     @staticmethod
     @pytest.fixture(scope="function")
     def set_env_variables():
-        envvars = {"default_caa_domains": "example.com|example.net"}
+        envvars = {
+            "default_caa_domains": "example.com|example.net",
+            "uvicorn_server_timeout_keep_alive": "25",
+        }
         with pytest.MonkeyPatch.context() as function_scoped_monkeypatch:
             for k, v in envvars.items():
                 function_scoped_monkeypatch.setenv(k, v)
@@ -78,6 +81,8 @@ class TestMpicCaaCheckerService:
         )
         assert config["default_caa_domains"] == ["example.com", "example.net"]
         assert config["log_level"] == 5
+        # uvicorn_server_timeout_keep_alive would be better checked in an integration test (can mock it though)
+        assert config["uvicorn_server_timeout_keep_alive"] == "25"
 
     @staticmethod
     def create_caa_check_response():

--- a/api-implementation/tests/unit/test_mpic_coordinator_service.py
+++ b/api-implementation/tests/unit/test_mpic_coordinator_service.py
@@ -205,7 +205,7 @@ class TestMpicCoordinatorService:
         assert response.status_code == status.HTTP_200_OK
         assert all(text in log_contents for text in ["mpic_coordinator", "TRACE"])  # Verify the log level was set
 
-    def service__should_return_app_config_diagnostics_give_diagnostics_request(self):
+    def service__should_return_app_config_diagnostics_give_diagnostics_request(self, set_env_variables):
         with TestClient(app) as client:
             response = client.get("/configz")
         assert response.status_code == status.HTTP_200_OK
@@ -220,6 +220,7 @@ class TestMpicCoordinatorService:
         assert config["http_client_keepalive_timeout_seconds"] == 60.0
         assert config["log_level"] == 5
         # uvicorn_server_timeout_keep_alive would be better checked in an integration test (can mock it though)
+        assert config["uvicorn_server_timeout_keep_alive"] == "25"
 
     @staticmethod
     def get_perspectives_by_code_dict_from_file() -> dict[str, RemotePerspective]:

--- a/api-implementation/tests/unit/test_mpic_coordinator_service.py
+++ b/api-implementation/tests/unit/test_mpic_coordinator_service.py
@@ -11,6 +11,7 @@ from aiohttp import ClientResponse
 from fastapi import status
 from fastapi.testclient import TestClient
 from multidict import CIMultiDictProxy, CIMultiDict
+from open_mpic_core.common_domain.enum.regional_internet_registry import RegionalInternetRegistry
 from pydantic import TypeAdapter
 from requests import Response
 from yarl import URL
@@ -110,7 +111,7 @@ class TestMpicCoordinatorService:
 
             dcv_check_request = ValidCheckCreator.create_valid_dns_check_request()
             check_response = await service.call_remote_perspective(
-                RemotePerspective(code="test-1", rir="rir1"), CheckType.DCV, dcv_check_request
+                RemotePerspective(code="test-1", rir=RegionalInternetRegistry.ARIN), CheckType.DCV, dcv_check_request
             )
             assert check_response.check_passed is True
             # hijacking the value of 'details.found_at' to verify that the right arguments got passed to the call

--- a/api-implementation/tests/unit/test_mpic_coordinator_service.py
+++ b/api-implementation/tests/unit/test_mpic_coordinator_service.py
@@ -49,6 +49,7 @@ class TestMpicCoordinatorService:
             "absolute_max_attempts": "2",
             "hash_secret": "test_secret",
             "http_client_timeout_seconds": "15",
+            "uvicorn_server_timeout_keep_alive": "25",
         }
         with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
             for k, v in envvars.items():
@@ -216,7 +217,9 @@ class TestMpicCoordinatorService:
         assert config["default_perspective_count"] == 2
         assert config["absolute_max_attempts"] == 2
         assert config["http_client_timeout_seconds"] == 15.0
+        assert config["http_client_keepalive_timeout_seconds"] == 60.0
         assert config["log_level"] == 5
+        # uvicorn_server_timeout_keep_alive would be better checked in an integration test (can mock it though)
 
     @staticmethod
     def get_perspectives_by_code_dict_from_file() -> dict[str, RemotePerspective]:

--- a/deployment-examples/amazon-ec2/aws_region_config.yaml
+++ b/deployment-examples/amazon-ec2/aws_region_config.yaml
@@ -72,57 +72,57 @@ available_regions:
   -
     code: "eu-central-1"
     name: "Europe (Frankfurt)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["eu-central-2"]
   -
     code: "eu-central-2"
     name: "Europe (Zurich)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["eu-central-1", "eu-south-1"]
   -
     code: "eu-north-1"
     name: "Europe (Stockholm)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "eu-south-1"
     name: "Europe (Milan)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["eu-central-2"]
   -
     code: "eu-south-2"
     name: "Europe (Spain)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "eu-west-1"
     name: "Europe (Ireland)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "eu-west-2"
     name: "Europe (London)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["eu-west-3"]
   -
     code: "eu-west-3"
     name: "Europe (Paris)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["eu-west-2"]
   -
     code: "il-central-1"
     name: "Israel (Tel Aviv)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: []
   -
     code: "me-central-1"
     name: "Middle East (UAE)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["me-south-1"]
   -
     code: "me-south-1"
     name: "Middle East (Bahrain)"
-    rir: "ripe"
+    rir: "ripe ncc"
     too_close_codes: ["me-central-1"]
   -
     code: "sa-east-1"

--- a/deployment-examples/kubernetes/open-mpic/mordor-east-1/coordinator/files/available_perspectives.yaml
+++ b/deployment-examples/kubernetes/open-mpic/mordor-east-1/coordinator/files/available_perspectives.yaml
@@ -5,5 +5,5 @@ available_regions:
     too_close_codes: ["gondor-south-1"] # Keep your enemies close
   - code: "shire-west-1"
     name: "The Shire (Hobbiton)"  
-    rir: "ripe ecc"  # it had to be a real RIR (no offence RIPE)
+    rir: "ripe ncc"  # it had to be a real RIR (no offence RIPE)
     too_close_codes: [] # Hobbits keep to themselves

--- a/deployment-examples/kubernetes/open-mpic/mordor-east-1/coordinator/files/available_perspectives.yaml
+++ b/deployment-examples/kubernetes/open-mpic/mordor-east-1/coordinator/files/available_perspectives.yaml
@@ -1,9 +1,9 @@
 available_regions:
-  - code: "mordor-east-1"  
+  - code: "mordor-east-1"
     name: "Mordor (The Black Gate)" 
-    rir: "sauron" # Who needs real RIRs?
+    rir: "arin"  # it had to be a real RIR (no offence ARIN)
     too_close_codes: ["gondor-south-1"] # Keep your enemies close
-  - code: "shire-west-1"  
+  - code: "shire-west-1"
     name: "The Shire (Hobbiton)"  
-    rir: "iarpa" # International Association for Responsible Pipeweed Agriculture
+    rir: "ripe ecc"  # it had to be a real RIR (no offence RIPE)
     too_close_codes: [] # Hobbits keep to themselves

--- a/deployment-examples/local-docker-compose/README.md
+++ b/deployment-examples/local-docker-compose/README.md
@@ -30,6 +30,16 @@ Only use valid, real RIR codes (e.g., "ARIN") in this file.
 If this file is improperly configured, the coordinator cannot reliably enforce a valid set of corroborating perspectives
 and may return results that are not valid to allow issuance. Invalid RIR codes will result in a runtime error.
 
+List of valid RIR codes:
+- ARIN
+- RIPE NCC
+- APNIC
+- LACNIC
+- AFRINIC
+
+The application in case-insensitive for RIR codes, but be sure to include the space if using "RIPE NCC".
+
+
 Modify the yaml file to add or remove perspectives as needed.
 
 It is recommended that the `available_perspectives.yaml` file be kept in sync with the perspectives configured in the

--- a/deployment-examples/local-docker-compose/README.md
+++ b/deployment-examples/local-docker-compose/README.md
@@ -7,12 +7,55 @@ This guide will help you set up and run all MPIC services using Docker Compose a
 - Docker installed on your machine
 - Docker Compose installed on your machine
 
-## Setup
+## Setup (Configuring the Services)
 
-1. Copy `config.example.yaml` to `config.yaml` to use the default config.
-2. Copy `resources/available_perspectives.example.yaml` to `resources/available_perspectives.yaml`
-3. Copy `common_config/log_config.example.yaml` to `common_config/log_config.yaml`
-4. Copy `common_config/uvicorn_config.example.yaml` to `common_config/uvicorn_config.yaml`
+### config.yaml
+Copy `compose.example.yaml` to `compose.yaml` to use the default config.
+
+`compose.yaml` defines your Docker Compose configuration. It lists your MPIC services
+(coordinator, CAA checkers, DCV checkers), other services (Traefik, Unbound), configures the network,
+sets up the volumes for each service (for mounting service-specific configuration), and directly defines configuration
+for each of the MPIC services.
+
+### available_perspectives.yaml
+Copy `resources/available_perspectives.example.yaml` to `resources/available_perspectives.yaml`, then modify it as
+appropriate for your deployment.
+
+This yaml file lists all the perspectives to which you are deploying your CAA and DCV checkers. It is consumed by
+the coordinator service to determine which perspectives can be used for each check. It is also used by the
+coordinator to determine whether a given set of corroborating perspectives is _valid_ by inspecting the RIR (Regional
+Internet Registry) that is specified for each perspective.
+
+Only use valid, real RIR codes (e.g., "ARIN") in this file.
+If this file is improperly configured, the coordinator cannot reliably enforce a valid set of corroborating perspectives
+and may return results that are not valid to allow issuance. Invalid RIR codes will result in a runtime error.
+
+Modify the yaml file to add or remove perspectives as needed.
+
+It is recommended that the `available_perspectives.yaml` file be kept in sync with the perspectives configured in the
+`compose.yaml` file (i.e., the perspectives to which you have deployed a checker).
+You will not encounter errors if the yaml file defines extra perspectives to which you have not deployed a checker. 
+You will, however, encounter errors if the yaml file does not define all the perspectives to which you _have_ deployed a checker.
+
+Make sure the codes in the `available_perspectives.yaml` file correspond to the perspective codes used to specify CAA 
+and DCV checker URLs in the `compose.yaml` file (as part of coordinator configuration).
+
+### log_config.yaml
+Copy `common_config/log_config.example.yaml` to `common_config/log_config.yaml`
+
+This file defines the logging configuration for the services. You can customize the logging level and format as needed.
+
+`TRACE` level is the lowest level of logging and will log everything including timing metrics. 
+It is recommended to use `INFO` or `DEBUG` level for production deployments.
+
+### uvicorn_config.yaml
+Copy `common_config/uvicorn_config.example.yaml` to `common_config/uvicorn_config.yaml`
+
+This file defines the Uvicorn configuration for the services. Uvicorn is the web server used to run the FastAPI 
+applications that implement the MPIC services.
+
+You can customize the host, port, server-side HTTP connection timeout, number of workers,
+and other settings as needed.
 
 ## Running the Services
 

--- a/deployment-examples/local-docker-compose/compose.build.example.yaml
+++ b/deployment-examples/local-docker-compose/compose.build.example.yaml
@@ -169,6 +169,7 @@ configs:
       absolute_max_attempts=2
       hash_secret=hash_secret
       http_client_timeout_seconds=5
+      http_client_keepalive_timeout_seconds=120
   log_config:
     file: ./common_config/log_config.yaml
   uvicorn_config:

--- a/deployment-examples/local-docker-compose/compose.example.yaml
+++ b/deployment-examples/local-docker-compose/compose.example.yaml
@@ -152,7 +152,8 @@ configs:
       default_perspective_count=2
       absolute_max_attempts=2
       hash_secret=hash_secret
-      http_client_timeout_seconds=5
+      http_client_timeout_seconds=30
+      http_client_keepalive_timeout_seconds=120
   log_config:
     file: ./common_config/log_config.yaml
   uvicorn_config:


### PR DESCRIPTION
The `/configz` endpoints now also display things like Uvicorn server-side connection keep-alive.

Added some content in READMEs about the `available_perspectives.yaml` file.