### PR TITLE
Add step to print labels in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,6 @@ jobs:
           file: api-implementation/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,13 +82,13 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
-      - name: Get core version from pyproject.toml
+      - name: Get Open MPIC Core version
         id: openMpicCoreVersion
         uses: mikefarah/yq@master
         with:
           cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
 
-      - name: Get OpenMPIC Spec Version from pyproject.toml
+      - name: Get Open MPIC Spec Version
         id: openMpicSpecVersion
         uses: mikefarah/yq@master
         with:
@@ -98,15 +98,15 @@ jobs:
         id: image-desc
         run: |
           # Keep the single-line description for Docker annotations
-          DESCRIPTION="OpenMPIC ${{ matrix.service }} service | OpenMpicCore Version: ${{ steps.openMpicCoreVersion.outputs.result }} | OpenMPIC Spec Version: ${{ steps.openMpicSpecVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
+          DESCRIPTION="Open MPIC ${{ matrix.service }} service | Open Mpic Core Version: ${{ steps.openMpicCoreVersion.outputs.result }} | Open MPIC Spec Version: ${{ steps.openMpicSpecVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
           echo "DESC=$DESCRIPTION" >> $GITHUB_OUTPUT
 
           # Add a nicely formatted description to the job summary
           echo "### 🐳 Image Description" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Service:** OpenMPIC ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
-          echo "**OpenMPIC Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "**OpenMPIC Spec Version:** ${{ steps.openMpicSpecVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Open MPIC Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Open MPIC Spec Version:** ${{ steps.openMpicSpecVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Build Time:** ${{ needs.shared-tags.outputs.timestamp }}" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ needs.shared-tags.outputs.branch-name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}
+          outputs: type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}"
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
-          outputs: type=image,name=target
-          annotations: ${{ steps.meta.outputs.annotations }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=MPIC standard API implementation leveraging FastAPI and Docker.
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,org.opencontainers.image.version=vX.X.X 
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}"
+          outputs: type=image,name=target,'annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}'
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,13 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
-      - name: Get version from toml
+      - name: Get core version from pyprojet.toml
         id: openMpicCoreVersion
         uses: mikefarah/yq@master
         with:
           cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core"))' api-implementation/pyproject.toml
-
+      - name: Print Core Version
+        run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
       # This step sets up QEMU for cross-platform builds.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -111,7 +112,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: "type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore $ {{ steps.openMpicCoreVersion.outputs.result }}"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        service: [coordinator]
-        # TEMPORARY TEST
-        # service: [coordinator, dcv_checker, caa_checker]
+        service: [coordinator, dcv_checker, caa_checker]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,14 @@ jobs:
           severity: "CRITICAL,HIGH"
       - name: Print labels
         run: echo "${{ steps.meta.outputs.labels }}"
+      - name: Create image description
+        id: description
+        run: |
+          echo "DESC<<EOF" >> $GITHUB_OUTPUT
+          echo "openMPIC ${{ matrix.service }} service" >> $GITHUB_OUTPUT
+          echo "OpenMpicCore version: ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_OUTPUT
+          echo "Built on: $(date)" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
       - name: Build and push image
         id: push
         uses: docker/build-push-action@v6
@@ -112,7 +120,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             # set timestamp tag
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
             # set branch-timestamp tag
-            type=raw,value={{github.ref_name}}-{{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{github.ref_name}}-{{date 'YYYYMMDD-HHmmss'}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,6 @@ jobs:
             type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.description=Custom description labels
           annotations: |
             org.opencontainers.image.description=Custom description annotations
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
           tags: |
             # set timestamp tag
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            # set branch-timestamp tag
+            type=raw,value={{github.ref}}-{{date 'YYYYMMDD-HHmmss'}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line.
-
+          outputs: type=image,name=target
+          annotations: |
+            index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line.
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,35 @@ jobs:
         with:
           options: "--check --verbose --line-length 120"
           src: "api-implementation/src"
+  shared-tags:
+    name: Shared Tags
+    runs-on: ubuntu-latest
+    outputs:
+      branch-name: ${{ steps.branch-name.outputs.BRANCH_NAME }}
+      timestamp: ${{ steps.timestamp.outputs.TIMESTAMP }}
+      legacy-timestamp: ${{ steps.legacy-timestamp.outputs.LEGACY-TIMESTAMP }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate sanitized branch name for tag
+        id: branch-name
+        # This step generates a sanitized branch name for tagging the Docker image. It replaces hyphens with dots in the branch name.
+        run: echo "BRANCH_NAME=${GITHUB_REF_NAME//-/.}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate legacy-timestamp format in shared output for synchronization with matrix
+        id: legacy-timestamp
+        # This is to support existing tags that are already in the legacy format. It generates a timestamp in a legacy format for tagging the Docker images. 
+        run: echo "LEGACY-TIMESTAMP=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Generate timestamp for tag in ISO 8601-1:2019 basic format
+        id: timestamp
+        # This step generates a timestamp in ISO 8601-1:2019 format for tagging the Docker image.
+        run: echo "TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_OUTPUT"
+
   Image-Build:
     runs-on: ubuntu-latest
+    needs: [shared-tags]
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
@@ -34,11 +61,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Generate sanitized branch name for tag
-        id: generate-branch-name
-        # This step generates a sanitized branch name for tagging the Docker image. It replaces hyphens with dots in the branch name.
-        run: echo "BRANCH_NAME=${GITHUB_REF_NAME//-/.}" >> $GITHUB_ENV
 
       # This step uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Authenticate to GitHub Container Registry
@@ -56,9 +78,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
           tags: |
             # set timestamp tag
-            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{ needs.shared-tags.outputs.legacy-timestamp }}
             # set branch-timestamp tag
-            type=raw,value=${{ env.BRANCH_NAME }}-{{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Generate legacy-timestamp format in shared output for synchronization with matrix
         id: legacy-timestamp
-        # This is to support existing tags that are already in the legacy format. It generates a timestamp in a legacy format for tagging the Docker images. 
+        # This is to support existing tags that are already in the legacy format. It generates a timestamp in a legacy format for tagging the Docker images.
         run: echo "LEGACY-TIMESTAMP=$(date -u +'%Y%m%d-%H%M%S')" >> "$GITHUB_OUTPUT"
 
       - name: Generate timestamp for tag in ISO 8601-1:2019 basic format
@@ -153,8 +153,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
-          outputs: |
-            type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}"
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Python Version
+        id: python-version
+        # read the ${{ matrix.service }}/.python-version file and load the version into a variable that is used in the next step
+        run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
+        # the variable is now available as $PYTHON_VERSION
+
+      - name: Get core version from pyproject.toml
+        id: openMpicCoreVersion
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
+      - name: Print Core Version
+        run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -92,25 +106,11 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
           annotations: |
-            org.opencontainers.image.description=Custom description annotations
-
+            org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
           DOCKER_METADATA_SET_OUTPUT_ENV: true
 
-      - name: Get Python Version
-        id: python-version
-        # read the ${{ matrix.service }}/.python-version file and load the version into a variable that is used in the next step
-        run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
-        # the variable is now available as $PYTHON_VERSION
-
-      - name: Get core version from pyproject.toml
-        id: openMpicCoreVersion
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
-      - name: Print Core Version
-        run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
       # This step sets up QEMU for cross-platform builds.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="MPIC standard API implementation leveraging FastAPI and Docker."
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore: $ {{ steps.openMpicCoreVersion.outputs.result }}
+          outputs: "type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore $ {{ steps.openMpicCoreVersion.outputs.result }}"
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,10 @@ jobs:
             type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.description=Custom description labels
           annotations: |
-            org.opencontainers.image.description=Custom description
+            org.opencontainers.image.description=Custom description annotations
 
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,12 +95,8 @@ jobs:
       - name: Prepare image description
         id: image-desc
         run: |
-          echo "DESC<<EOF" >> $GITHUB_OUTPUT
-          echo "OpenMPIC ${{ matrix.service }} service" >> $GITHUB_OUTPUT
-          echo "with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_OUTPUT
-          echo "Built on: $(date -u)" >> $GITHUB_OUTPUT
-          echo "Branch: ${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          DESCRIPTION="OpenMPIC ${{ matrix.service }} service | with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
+          echo "DESC=$DESCRIPTION" >> $GITHUB_OUTPUT
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           # Add a nicely formatted description to the job summary
           echo "### 🐳 Image Description" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Service:** OpenMPIC ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Service:** Open MPIC ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
           echo "**Open MPIC Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Open MPIC Spec Version:** ${{ steps.openMpicSpecVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Build Time:** ${{ needs.shared-tags.outputs.timestamp }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
-          outputs: type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}"
+          outputs: |
+            type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.meta.outputs.annotations }}"
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
           outputs: type=image,name=target
-          annotations: |
-            index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line.
+          annotations: "index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line."
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,9 +91,8 @@ jobs:
             type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
-          labels: |
-            org.opencontainers.image.title=MyCustomTitle
-            index:org.opencontainers.image.description=Custom description
+          annotations: |
+            org.opencontainers.image.description=Custom description
 
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,10 @@ jobs:
             type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=MyCustomTitle
+            org.opencontainers.image.description=Custom description
+
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         id: openMpicSpecVersion
         uses: mikefarah/yq@master
         with:
-          cmd: yq -oy '.project.dependencies.[] | select(test("^spec_version")) | split("==")[1]' api-implementation/pyproject.toml
+          cmd: yq -oy '.tool.api.spec_version' api-implementation/pyproject.toml
 
       - name: Prepare image description
         id: image-desc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,21 +87,26 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
-      - name: Print Core Version
-        run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
+
+      - name: Get OpenMPIC Spec Version from pyproject.toml
+        id: openMpicSpecVersion
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -oy '.project.dependencies.[] | select(test("^spec_version")) | split("==")[1]' api-implementation/pyproject.toml
 
       - name: Prepare image description
         id: image-desc
         run: |
           # Keep the single-line description for Docker annotations
-          DESCRIPTION="OpenMPIC ${{ matrix.service }} service | with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
+          DESCRIPTION="OpenMPIC ${{ matrix.service }} service | OpenMpicCore Version: ${{ steps.openMpicCoreVersion.outputs.result }} | OpenMPIC Spec Version: ${{ steps.openMpicSpecVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
           echo "DESC=$DESCRIPTION" >> $GITHUB_OUTPUT
 
           # Add a nicely formatted description to the job summary
           echo "### 🐳 Image Description" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Service:** OpenMPIC ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**OpenMPIC Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**OpenMPIC Spec Version:** ${{ steps.openMpicSpecVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Build Time:** ${{ needs.shared-tags.outputs.timestamp }}" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** ${{ needs.shared-tags.outputs.branch-name }}" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,43 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Get container package version ID
+        if: success() && steps.push.outcome == 'success'
+        id: package-id
+        run: |
+          # Wait briefly for the package to be available in the API
+          sleep 10
+
+          # Tag to find (use the branch-timestamp tag as it's unique)
+          TAG="${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}"
+
+          # Call the GitHub API to find the package version ID
+          RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.service }}/versions")
+
+          # Parse the response to find the package version with our tag
+          PACKAGE_VERSION_ID=$(echo "$RESPONSE" | jq -r '.[] | select(.metadata.container.tags[] | contains("'"$TAG"'")) | .id')
+
+          if [ -n "$PACKAGE_VERSION_ID" ]; then
+            echo "Found package version ID: $PACKAGE_VERSION_ID"
+            echo "PACKAGE_VERSION_ID=$PACKAGE_VERSION_ID" >> $GITHUB_OUTPUT
+            
+            # Update the step summary with direct links
+            echo "**Direct Package Links:**" >> $GITHUB_STEP_SUMMARY
+            echo "- [Package Version Link](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}/$PACKAGE_VERSION_ID)" >> $GITHUB_STEP_SUMMARY
+            echo "- [Branch-Timestamp Tag ($TAG)](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "---" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Warning: Could not find package version ID for tag $TAG"
+            echo "**Package Links:**" >> $GITHUB_STEP_SUMMARY
+            echo "- [All Versions](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Filter by Tag ($TAG)](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "---" >> $GITHUB_STEP_SUMMARY
+          fi
+
   # Image-Build-Unbound:
   #   runs-on: ubuntu-latest
   #   permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             # set timestamp tag
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
             # set branch-timestamp tag
-            type=raw,value={{github.ref}}-{{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value={{github.ref_name}}-{{date 'YYYYMMDD-HHmmss'}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
+          # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line.
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,11 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=MyCustomTitle
-            org.opencontainers.image.description=Custom description
+            index:org.opencontainers.image.description=Custom description
 
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_SET_OUTPUT_ENV: true
 
       - name: Get Python Version
         id: python-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}
+          outputs: type=image,name=target,"annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}"
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
         # This step generates a timestamp in ISO 8601-1:2019 format for tagging the Docker image.
         run: echo "TIMESTAMP=$(date -u +'%Y%m%dT%H%M%SZ')" >> "$GITHUB_OUTPUT"
 
+      - name: Tags Summary
+        run: |
+          echo '### Generated Image Tags 📦' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
+          echo "- Branch Name: ${{ steps.branch-name.outputs.BRANCH_NAME }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Timestamp: ${{ steps.timestamp.outputs.TIMESTAMP }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Legacy Timestamp: ${{ steps.legacy-timestamp.outputs.LEGACY-TIMESTAMP }}" >> $GITHUB_STEP_SUMMARY
+
   Image-Build:
     runs-on: ubuntu-latest
     needs: [shared-tags]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,16 @@ jobs:
       - name: Print Core Version
         run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
 
+      - name: Prepare image description
+        id: image-desc
+        run: |
+          echo "DESC<<EOF" >> $GITHUB_OUTPUT
+          echo "OpenMPIC ${{ matrix.service }} service" >> $GITHUB_OUTPUT
+          echo "with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_OUTPUT
+          echo "Built on: $(date -u)" >> $GITHUB_OUTPUT
+          echo "Branch: ${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -106,7 +116,7 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
           annotations: |
-            org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
+            org.opencontainers.image.description=${{ steps.image-desc.outputs.DESC }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
           DOCKER_METADATA_SET_OUTPUT_ENV: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+
+      - name: Generate sanitized branch name for tag
+        id: generate-branch-name
+        # This step generates a sanitized branch name for tagging the Docker image. It replaces hyphens with dots in the branch name.
+        run: echo "BRANCH_NAME=${GITHUB_REF_NAME//-/.}" >> $GITHUB_ENV
+
+      # This step uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Authenticate to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -52,7 +58,7 @@ jobs:
             # set timestamp tag
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
             # set branch-timestamp tag
-            type=raw,value=${{github.ref_name}}-{{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{ env.BRANCH_NAME }}-{{date 'YYYYMMDD-HHmmss'}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,9 +227,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    strategy:
-      matrix:
-        service: [unbound]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -246,7 +243,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound
           tags: |
             # set timestamp tag
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
@@ -270,11 +267,11 @@ jobs:
           load: true
           context: unbound
           file: unbound/Dockerfile
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound:${{ env.TEST_TAG }}
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound:${{ env.TEST_TAG }}
           format: "table"
           exit-code: "1"
           ignore-unfixed: true
@@ -296,6 +293,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,8 @@ jobs:
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
-
+      - name: Print labels
+        run: echo "${{ steps.meta.outputs.labels }}"
       - name: Build and push image
         id: push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
           file: api-implementation/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         id: openMpicCoreVersion
         uses: mikefarah/yq@master
         with:
-          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core"))' api-implementation/pyproject.toml
+          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
       - name: Print Core Version
         run: echo "${{ steps.openMpicCoreVersion.outputs.result }}"
       # This step sets up QEMU for cross-platform builds.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
-      - name: Get core version from pyprojet.toml
+      - name: Get core version from pyproject.toml
         id: openMpicCoreVersion
         uses: mikefarah/yq@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
           outputs: type=image,name=target
-          annotations: "index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.\nThis is the second line.\nAnd the third line."
+          # Use URL-encoded newline (%0A) instead of \n
+          # Use block scalar | for readability - it will pass %0A literally
+          annotations: |
+            index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.%0AThis is the second line.%0AAnd the third line.
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-      - name: Get container package version ID
+      - name: Add container registry links to summary
         if: success() && steps.push.outcome == 'success'
         id: package-id
         run: |
@@ -304,3 +304,42 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Add container registry links to summary
+        if: success() && steps.push.outcome == 'success'
+        id: package-id
+        run: |
+          # Wait briefly for the package to be available in the API
+          sleep 10
+
+          # Tag to find (use the branch-timestamp tag as it's unique)
+          TAG="${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}"
+
+          # Try to get the package version ID first
+          echo "Attempting to find exact package version ID..."
+          RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/unbound/versions")
+
+          # Parse the response to find the package version with our tag
+          PACKAGE_VERSION_ID=$(echo "$RESPONSE" | jq -r '.[] | select(.metadata.container.tags[] | contains("'"$TAG"'")) | .id')
+
+          # Update the step summary with the appropriate links based on what we found
+          echo "### 📦 Container Registry Links" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -n "$PACKAGE_VERSION_ID" ]; then
+            echo "Found package version ID: $PACKAGE_VERSION_ID"
+            echo "PACKAGE_VERSION_ID=$PACKAGE_VERSION_ID" >> $GITHUB_OUTPUT
+            
+            # Direct link with specific package version ID AND tag
+            echo "- [📋 Package Version Link](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/unbound/$PACKAGE_VERSION_ID?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Note: Could not determine exact package version ID."
+            
+            # Add the main container page as fallback
+            echo "- [📋 Container Registry](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/unbound)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
       - name: Get Python Version
         id: python-version
@@ -114,10 +116,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
           outputs: type=image,name=target
-          # Use URL-encoded newline (%0A) instead of \n
-          # Use block scalar | for readability - it will pass %0A literally
-          annotations: |
-            index:org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}.%0AThis is the second line.%0AAnd the third line.
+          annotations: ${{ steps.meta.outputs.annotations }}
+
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="MPIC standard API implementation leveraging FastAPI and Docker."
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=MPIC standard API implementation leveraging FastAPI and Docker.
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        service: [coordinator, dcv_checker, caa_checker]
+        service: [coordinator]
+        # TEMPORARY TEST
+        # service: [coordinator, dcv_checker, caa_checker]
 
     steps:
       - name: Checkout repository
@@ -103,7 +105,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,org.opencontainers.image.version=vX.X.X 
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,annotation-index.org.opencontainers.image.version=v0.0.0
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation
@@ -113,82 +115,82 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-  Image-Build-Unbound:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    strategy:
-      matrix:
-        service: [unbound]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-      - name: Authenticate to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  # Image-Build-Unbound:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     packages: write
+  #     attestations: write
+  #     id-token: write
+  #   strategy:
+  #     matrix:
+  #       service: [unbound]
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #     # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+  #     - name: Authenticate to GitHub Container Registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
-          tags: |
-            # set timestamp tag
-            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+  #     # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+  #     - name: Extract metadata (tags, labels) for Docker
+  #       id: meta
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+  #         tags: |
+  #           # set timestamp tag
+  #           type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+  #           # set latest tag for default branch
+  #           type=raw,value=latest,enable={{is_default_branch}}
 
-      # This step sets up QEMU for cross-platform builds.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  #     # This step sets up QEMU for cross-platform builds.
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
 
-      # This step sets up Docker Buildx for multi-platform builds.
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      # Built unbound image.
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-      - name: Build and export to Docker
-        uses: docker/build-push-action@v6
-        with:
-          load: true
-          context: unbound
-          file: unbound/Dockerfile
-          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL,HIGH"
+  #     # This step sets up Docker Buildx for multi-platform builds.
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     # Built unbound image.
+  #     # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+  #     # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+  #     # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+  #     - name: Build and export to Docker
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         load: true
+  #         context: unbound
+  #         file: unbound/Dockerfile
+  #         tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+  #     - name: Run Trivy vulnerability scanner
+  #       uses: aquasecurity/trivy-action@0.28.0
+  #       with:
+  #         image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+  #         format: "table"
+  #         exit-code: "1"
+  #         ignore-unfixed: true
+  #         vuln-type: "os,library"
+  #         severity: "CRITICAL,HIGH"
 
-      - name: Build and push image
-        id: push
-        uses: docker/build-push-action@v6
-        with:
-          context: unbound
-          platforms: linux/amd64,linux/arm64
-          file: unbound/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  #     - name: Build and push image
+  #       id: push
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: unbound
+  #         platforms: linux/amd64,linux/arm64
+  #         file: unbound/Dockerfile
+  #         push: true
+  #         tags: ${{ steps.meta.outputs.tags }}
+  #         labels: ${{ steps.meta.outputs.labels }}
 
-      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+  #     # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
+  #     - name: Generate artifact attestation
+  #       uses: actions/attest-build-provenance@v1
+  #       with:
+  #         subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+  #         subject-digest: ${{ steps.push.outputs.digest }}
+  #         push-to-registry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,14 +99,6 @@ jobs:
           severity: "CRITICAL,HIGH"
       - name: Print labels
         run: echo "${{ steps.meta.outputs.labels }}"
-      - name: Create image description
-        id: description
-        run: |
-          echo "DESC<<EOF" >> $GITHUB_OUTPUT
-          echo "openMPIC ${{ matrix.service }} service" >> $GITHUB_OUTPUT
-          echo "OpenMpicCore version: ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_OUTPUT
-          echo "Built on: $(date)" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
       - name: Build and push image
         id: push
         uses: docker/build-push-action@v6
@@ -120,7 +112,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,'annotation-index.org.opencontainers.image.description=${{ steps.description.outputs.DESC }}'
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,12 +219,6 @@ jobs:
             echo "- [📋 Container Registry](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }})" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Add pull command for convenience
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Pull Command:** 📥" >> $GITHUB_STEP_SUMMARY
-          echo "```bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:$TAG" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,82 +220,82 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
 
-  # Image-Build-Unbound:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     packages: write
-  #     attestations: write
-  #     id-token: write
-  #   strategy:
-  #     matrix:
-  #       service: [unbound]
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #     # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
-  #     - name: Authenticate to GitHub Container Registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+  Image-Build-Unbound:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        service: [unbound]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Authenticate to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
-  #     - name: Extract metadata (tags, labels) for Docker
-  #       id: meta
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
-  #         tags: |
-  #           # set timestamp tag
-  #           type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-  #           # set latest tag for default branch
-  #           type=raw,value=latest,enable={{is_default_branch}}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          tags: |
+            # set timestamp tag
+            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
-  #     # This step sets up QEMU for cross-platform builds.
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
+      # This step sets up QEMU for cross-platform builds.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-  #     # This step sets up Docker Buildx for multi-platform builds.
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
-  #     # Built unbound image.
-  #     # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-  #     # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-  #     # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
-  #     - name: Build and export to Docker
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         load: true
-  #         context: unbound
-  #         file: unbound/Dockerfile
-  #         tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
-  #     - name: Run Trivy vulnerability scanner
-  #       uses: aquasecurity/trivy-action@0.28.0
-  #       with:
-  #         image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
-  #         format: "table"
-  #         exit-code: "1"
-  #         ignore-unfixed: true
-  #         vuln-type: "os,library"
-  #         severity: "CRITICAL,HIGH"
+      # This step sets up Docker Buildx for multi-platform builds.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # Built unbound image.
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          context: unbound
+          file: unbound/Dockerfile
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:${{ env.TEST_TAG }}
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
 
-  #     - name: Build and push image
-  #       id: push
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         context: unbound
-  #         platforms: linux/amd64,linux/arm64
-  #         file: unbound/Dockerfile
-  #         push: true
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: unbound
+          platforms: linux/amd64,linux/arm64
+          file: unbound/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
-  #     # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
-  #     - name: Generate artifact attestation
-  #       uses: actions/attest-build-provenance@v1
-  #       with:
-  #         subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
-  #         subject-digest: ${{ steps.push.outputs.digest }}
-  #         push-to-registry: true
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,annotation-index.org.opencontainers.image.version=v0.0.0
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,annotation.org.opencontainers.image.title=testtitle
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,12 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
+      - name: Get version from toml
+        id: openMpicCoreVersion
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core"))' api-implementation/pyproject.toml
+
       # This step sets up QEMU for cross-platform builds.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -105,7 +111,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service container image.,annotation.org.opencontainers.image.title=testtitle
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=openMPIC ${{ matrix.service }} service with OpenMpicCore: $ {{ steps.openMpicCoreVersion.outputs.result }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[Using artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)."
       - name: Generate artifact attestation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,7 @@ jobs:
 
   Image-Build-Unbound:
     runs-on: ubuntu-latest
+    needs: [shared-tags]
     permissions:
       contents: read
       packages: write
@@ -251,7 +252,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/unbound
           tags: |
             # set timestamp tag
-            type=raw,value={{date 'YYYYMMDD-HHmmss'}}
+            type=raw,value=${{ needs.shared-tags.outputs.legacy-timestamp }}
+            # set branch-timestamp tag
+            type=raw,value=${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,8 @@ jobs:
           # Tag to find (use the branch-timestamp tag as it's unique)
           TAG="${{ needs.shared-tags.outputs.branch-name }}-${{ needs.shared-tags.outputs.timestamp }}"
 
-          # Call the GitHub API to find the package version ID
+          # Try to get the package version ID first
+          echo "Attempting to find exact package version ID..."
           RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/${{ matrix.service }}/versions")
@@ -201,24 +202,31 @@ jobs:
           # Parse the response to find the package version with our tag
           PACKAGE_VERSION_ID=$(echo "$RESPONSE" | jq -r '.[] | select(.metadata.container.tags[] | contains("'"$TAG"'")) | .id')
 
+          # Update the step summary with the appropriate links based on what we found
+          echo "### 📦 Container Registry Links" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
           if [ -n "$PACKAGE_VERSION_ID" ]; then
             echo "Found package version ID: $PACKAGE_VERSION_ID"
             echo "PACKAGE_VERSION_ID=$PACKAGE_VERSION_ID" >> $GITHUB_OUTPUT
             
-            # Update the step summary with direct links
-            echo "**Direct Package Links:**" >> $GITHUB_STEP_SUMMARY
-            echo "- [Package Version Link](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}/$PACKAGE_VERSION_ID)" >> $GITHUB_STEP_SUMMARY
-            echo "- [Branch-Timestamp Tag ($TAG)](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "---" >> $GITHUB_STEP_SUMMARY
+            # Direct link with specific package version ID AND tag
+            echo "- [📋 Package Version Link](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}/$PACKAGE_VERSION_ID?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "Warning: Could not find package version ID for tag $TAG"
-            echo "**Package Links:**" >> $GITHUB_STEP_SUMMARY
-            echo "- [All Versions](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }})" >> $GITHUB_STEP_SUMMARY
-            echo "- [Filter by Tag ($TAG)](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }}?tag=$TAG)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "Note: Could not determine exact package version ID."
+            
+            # Add the main container page as fallback
+            echo "- [📋 Container Registry](https://github.com/${{ github.repository_owner }}/open-mpic-containers/pkgs/container/${{ matrix.service }})" >> $GITHUB_STEP_SUMMARY
           fi
+
+          # Add pull command for convenience
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull Command:** 📥" >> $GITHUB_STEP_SUMMARY
+          echo "```bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}:$TAG" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
 
   # Image-Build-Unbound:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,20 @@ jobs:
       - name: Prepare image description
         id: image-desc
         run: |
+          # Keep the single-line description for Docker annotations
           DESCRIPTION="OpenMPIC ${{ matrix.service }} service | with OpenMpicCore ${{ steps.openMpicCoreVersion.outputs.result }} | Built on: ${{ needs.shared-tags.outputs.timestamp }} | Branch: ${{ needs.shared-tags.outputs.branch-name }}"
           echo "DESC=$DESCRIPTION" >> $GITHUB_OUTPUT
+
+          # Add a nicely formatted description to the job summary
+          echo "### 🐳 Image Description" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Service:** OpenMPIC ${{ matrix.service }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Core Version:** ${{ steps.openMpicCoreVersion.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Time:** ${{ needs.shared-tags.outputs.timestamp }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** ${{ needs.shared-tags.outputs.branch-name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.service }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -1,5 +1,5 @@
 # Start with any Python image - it's just for bootstrapping Hatch
-FROM python:3.13
+FROM python:3.13-alpine
 
 # Arg for path to specific service to build
 ARG SERVICE_PATH

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -6,8 +6,6 @@ ARG SERVICE_PATH
 
 RUN echo "building service from path: ${SERVICE_PATH}"
 
-LABEL org.opencontainers.image.description="Python service for the MPIC project"
-
 # Dist/package upgrade
 RUN apt-get update && apt-get dist-upgrade -y
 

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -1,5 +1,5 @@
 # Start with any Python image - it's just for bootstrapping Hatch
-FROM python:3.13-alpine
+FROM python:3.13.2
 
 # Arg for path to specific service to build
 ARG SERVICE_PATH

--- a/api-implementation/Dockerfile
+++ b/api-implementation/Dockerfile
@@ -6,6 +6,8 @@ ARG SERVICE_PATH
 
 RUN echo "building service from path: ${SERVICE_PATH}"
 
+LABEL org.opencontainers.image.description="Python service for the MPIC project"
+
 # Dist/package upgrade
 RUN apt-get update && apt-get dist-upgrade -y
 


### PR DESCRIPTION

This pull request enhances the GitHub Actions workflow for building and publishing Docker images by introducing shared tags, improving metadata management, and adding detailed summaries for build outputs. Additionally, it updates the base Python image in the `Dockerfile`.

### Workflow Enhancements:

* **Shared Tags Job**: Introduced a new `shared-tags` job to generate reusable outputs for branch names, timestamps (ISO 8601 and legacy formats), and a summary of generated tags. These outputs are used across other jobs for consistency. (`.github/workflows/build.yml`, [.github/workflows/build.ymlR20-R56](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R20-R56))
* **Improved Metadata and Annotations**: Updated the `docker/metadata-action` configuration to use the shared tags for generating Docker image tags and annotations. This includes adding descriptions and timestamps in the image annotations. (`.github/workflows/build.yml`, [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L51-R133) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L104-R179)
* **Container Registry Links**: Added a step to generate and include direct links to the container registry in the job summary, enhancing traceability for published images. (`.github/workflows/build.yml`, [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R189-L123) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L190-R345)

### Codebase Updates:

* **Python Base Image Update**: Updated the base Python image in the `api-implementation/Dockerfile` from `python:3.13` to `python:3.13.2` to ensure the latest patch version is used. (`api-implementation/Dockerfile`, [api-implementation/DockerfileL2-R2](diffhunk://#diff-fbd250f4aa6945d81802f8a398540320fe975e350c707b04150e1309930ac026L2-R2))