### PR TITLE
DNS Persistent DCV validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - uses: psf/black@25.1.0
         with:
           options: "--check --verbose --line-length 120"
           src: "api-implementation/src"

--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.6.0"
+version = "1.7.0"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -32,8 +32,8 @@ dependencies = [
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.2.0",
-    "aiohttp==3.12.14",
+    "open-mpic-core==6.3.0",
+    "aiohttp==3.13.3",
     "uvicorn>=0.34.3,<0.35.0",
     "black==25.1.0",
 ]
@@ -54,7 +54,7 @@ Issues = "https://github.com/open-mpic/open-mpic-restapi-server/issues"
 Source = "https://github.com/open-mpic/open-mpic-restapi-server"
 
 [tool.api]
-spec_version = "3.7.0"
+spec_version = "3.8.0"
 spec_repository = "https://github.com/open-mpic/open-mpic-specification"
 
 [tool.hatch]

--- a/api-implementation/tests/integration/test_deployed_mpic_api.py
+++ b/api-implementation/tests/integration/test_deployed_mpic_api.py
@@ -4,6 +4,7 @@ import pytest
 import time
 
 from open_mpic_core.common_domain.check_parameters import DcvDnsPersistentValidationParameters
+from open_mpic_core.mpic_coordinator.domain.mpic_response import MpicDcvResponse
 from pydantic import TypeAdapter
 
 from open_mpic_core import CaaCheckParameters, DcvWebsiteChangeValidationParameters, PerspectiveResponse
@@ -73,11 +74,8 @@ class TestDeployedMpicApi:
         response = api_client.post(MPIC_REQUEST_PATH, json.dumps(request.model_dump()))
         print("\nResponse:\n", json.dumps(json.loads(response.text), indent=4))  # pretty print response body
         assert response.status_code == 200
-        mpic_response: MpicCaaResponse = self.mpic_response_adapter.validate_json(response.text)
-        perspectives: list[PerspectiveResponse] = mpic_response.perspectives
+        mpic_response: MpicDcvResponse = self.mpic_response_adapter.validate_json(response.text)
         assert mpic_response.is_valid is True
-        assert mpic_response.domain_or_ip_target == request.domain_or_ip_target
-        assert len(perspectives) == request.orchestration_parameters.perspective_count
 
     @pytest.mark.skip(reason="working on getting the first test to pass")
     def api_should_return_200_and_failed_corroboration_given_failed_dcv_check(self, api_client):

--- a/api-implementation/tests/integration/test_deployed_mpic_api.py
+++ b/api-implementation/tests/integration/test_deployed_mpic_api.py
@@ -132,5 +132,3 @@ class TestDeployedMpicApi:
         response_body = json.loads(response.text)
         print("\nResponse:\n", json.dumps(response_body, indent=4))
         assert response_body["error"] == MpicRequestValidationMessages.REQUEST_VALIDATION_FAILED.key
-
-


### PR DESCRIPTION
This pull request updates the `open-mpic-restapi-server` to support the latest MPIC specification and core library, and adds a new integration test for DNS persistent validation. The main changes include dependency upgrades, a spec version bump, and expanded test coverage for a new DCV method.

Dependency and specification updates:

* Upgraded `open-mpic-core` dependency from `6.2.0` to `6.3.0` and `aiohttp` from `3.12.14` to `3.13.3` in `pyproject.toml` to ensure compatibility with the latest features and fixes.
* Bumped the project version from `1.6.0` to `1.7.0` and updated the API spec version from `3.7.0` to `3.8.0` in `pyproject.toml`. [[1]](diffhunk://#diff-8433e33d143b29b120ce52f18bfb31ed9755af5850ac45661a1d0d2e9ccb7f43L10-R10) [[2]](diffhunk://#diff-8433e33d143b29b120ce52f18bfb31ed9755af5850ac45661a1d0d2e9ccb7f43L57-R57)

Testing and validation improvements:

* Added a new integration test (`api_should_support_persistent_dns_validation_method`) in `test_deployed_mpic_api.py` to verify support for the persistent DNS DCV method, using the new `DcvDnsPersistentValidationParameters` class from `open-mpic-core`. [[1]](diffhunk://#diff-c9f6c5dc5cf153399a176db998d8e3dc622a1d9ae3451dcba325ad77add41eddR5-R6) [[2]](diffhunk://#diff-c9f6c5dc5cf153399a176db998d8e3dc622a1d9ae3451dcba325ad77add41eddR62-R81)