### PR TITLE
incorporated persistent dns bugfixes added in open-mpic-core v6.3.1

### DIFF
--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.3.1",
+    "open-mpic-core==6.3.2",
     "aiohttp==3.13.3",
     "uvicorn>=0.34.3,<0.35.0",
     "black==25.1.0",

--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.7.0"
+version = "1.7.1"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -32,7 +32,7 @@ dependencies = [
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.3.0",
+    "open-mpic-core==6.3.1",
     "aiohttp==3.13.3",
     "uvicorn>=0.34.3,<0.35.0",
     "black==25.1.0",


### PR DESCRIPTION
This pull request makes a minor update to the `api-implementation/pyproject.toml` file.
It pulls in the v6.3.1 of `open-mpic-core` to incorporate bug fixes to the Persistent DNS logic that checks validity and format of records. 

Dependency updates:

* Bumped the version of `open-mpic-core` from `6.3.0` to `6.3.1` to incorporate the latest fixes and features.

Project versioning:

* Updated the project version from `1.7.0` to `1.7.1` to reflect the new dependency update