### PR TITLE
Replace yq action with standard install. allows more control

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,17 +82,20 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
+      - name: Install yq
+        run: |
+          YQ_VERSION=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name')
+          wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
       - name: Get Open MPIC Core version
         id: openMpicCoreVersion
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml
+        run: echo "result=$(yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
 
       - name: Get Open MPIC Spec Version
         id: openMpicSpecVersion
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq -oy '.tool.api.spec_version' api-implementation/pyproject.toml
+        run: echo "result=$(yq -oy '.tool.api.spec_version' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
 
       - name: Prepare image description
         id: image-desc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,20 +82,17 @@ jobs:
         run: echo "PYTHON_VERSION=$(cat api-implementation/src/mpic_${{ matrix.service }}_service/.python-version)" >> $GITHUB_OUTPUT
         # the variable is now available as $PYTHON_VERSION
 
-      - name: Install yq
+      - name: Print `yq` version
         run: |
-          YQ_VERSION=$(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | jq -r '.tag_name')
-          wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
           yq --version
 
       - name: Get Open MPIC Core version
         id: openMpicCoreVersion
-        run: echo "result=$(yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
+        run: printf "result=$(yq -oy '.project.dependencies.[] | select(test("^open-mpic-core")) | split("==")[1]' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
 
       - name: Get Open MPIC Spec Version
         id: openMpicSpecVersion
-        run: echo "result=$(yq -oy '.tool.api.spec_version' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
+        run: printf "result=$(yq -oy '.tool.api.spec_version' api-implementation/pyproject.toml)" >> $GITHUB_OUTPUT
 
       - name: Prepare image description
         id: image-desc

--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.3.0",
+    "open-mpic-core==6.3.2",
     "aiohttp==3.13.3",
     "uvicorn>=0.34.3,<0.35.0",
     "black==25.1.0",


### PR DESCRIPTION
Switch to a standard installation method for yq, allowing for more control over its version and usage in the workflow.