### PR TITLE
updated black to 26.3.1 and bumped patch version

### DIFF
--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.7.2"
+version = "1.7.3"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==26.3.0",
+    "black==26.3.1",
 ]
 test = [
     "pytest==8.2.2",


### PR DESCRIPTION
This pull request makes minor updates to the `api-implementation/pyproject.toml` file, including a patch version bump and a development dependency update.

- Versioning:
  * Bumped the project version from `1.7.2` to `1.7.3` to reflect the latest changes.

- Development dependencies:
  * Updated the `black` code formatter in the `dev` dependencies from version `26.3.0` to `26.3.1`.