### PR TITLE
pulled in URI parse fix for Persistent DCV method, bumped patch version

### DIFF
--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.7.3"
+version = "1.7.4"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -32,7 +32,7 @@ dependencies = [
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.3.3",
+    "open-mpic-core==6.3.4",
     "aiohttp==3.13.3",
     "uvicorn>=0.34.3,<0.35.0",
 ]


### PR DESCRIPTION
This pull request updates dependencies in the `api-implementation/pyproject.toml` file to ensure compatibility and incorporate the latest fixes.

Dependency updates:

* Bumped the `open-mpic-core` dependency from version `6.3.3` to `6.3.4` to include recent updates and bug fixes.

Versioning:

* Updated the project version from `1.7.3` to `1.7.4` to reflect these dependency changes.