### PR TITLE
Incorporates new require_exact_case flag

### DIFF
--- a/api-implementation/pyproject.toml
+++ b/api-implementation/pyproject.toml
@@ -7,7 +7,7 @@ allow-direct-references = true
 
 [project]
 name = "open-mpic-restapi-server"
-version = "1.7.4"
+version = "1.8.0"
 description = 'MPIC standard API implementation leveraging FastAPI and Docker.'
 requires-python = ">=3.11"
 license = "MIT"
@@ -27,13 +27,13 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml==6.0.2",
-    "requests==2.32.4",
+    "requests==2.33.0",
     "dnspython==2.7.0",
     "pydantic==2.11.7",
     "fastapi[standard]>=0.120.1,<0.121.0",
     "starlette==0.49.1",
-    "open-mpic-core==6.3.4",
-    "aiohttp==3.13.3",
+    "open-mpic-core==6.4.0",
+    "aiohttp==3.13.4",
     "uvicorn>=0.34.3,<0.35.0",
 ]
 
@@ -56,7 +56,7 @@ Issues = "https://github.com/open-mpic/open-mpic-restapi-server/issues"
 Source = "https://github.com/open-mpic/open-mpic-restapi-server"
 
 [tool.api]
-spec_version = "3.8.0"
+spec_version = "3.9.0"
 spec_repository = "https://github.com/open-mpic/open-mpic-specification"
 
 [tool.hatch]


### PR DESCRIPTION
Dependency updates:

* Upgraded `requests` to version `2.33.0` to include the latest features and security fixes.
* Upgraded `open-mpic-core` to version `6.4.0` for improved core functionality and compatibility -- namely incorporating the `require_exact_case` flag for DCV methods Website Change (non-ACME) and DNX TXT change (non-ACME). The flag defaults to `true` (case-sensitive match), which is a _departure_ from the previous behavior where the default match was case-insensitive. To retain previous behavior, clients must explicitly set `require_exact_case` to False for those two methods. All other DCV methods remain case-insensitive or, in the case of ACME dns-01 and http-01, case-sensitive, as before.
* Upgraded `aiohttp` to version `3.13.4` for bug fixes and performance improvements.

Version and specification updates:

* Bumped the project version to `1.8.0` to reflect the new changes.
* Updated the API specification version to `3.9.0` to align with the latest standard.